### PR TITLE
Unbreak the entire site build.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ in
     echo $LOCALE_ARCHIVE
     cd site
     site build
-    mv _site $out
+    mv ../docs $out
   '';
 
   shell = haskellPackages.shellFor {


### PR DESCRIPTION
In 7db7397a4f5ca7264ff7b3090a7d0c44a5172975 the output dir was changed
to facilitate the build.sh script. This just adapts the Nix build to
work with `../docs` too.