### PR TITLE
Add podcast teaser.

### DIFF
--- a/docs/podcast/index.html
+++ b/docs/podcast/index.html
@@ -220,20 +220,20 @@
   </div>
 
 
-<div class="max-w-screen-md mx-auto grid gap-8">
-
-
-  <div class="bg-gray-100 px-6 sm:px-12 space-y-4 py-12">
-
+<div class="max-w-screen-xl mx-auto">
+  <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-12 lg:py-24">
+    <h2 class="text-center text-2xl-4xl font-normal">Episode 0: Teaser</h2>
+    <div class="mt-8  space-y-8 max-w-2xl mx-auto">
       <p>
-      		We are starting a new Haskell-focused podcast where we interview guests from the Haskell community. The hosts are Niki Vazou, Joachim Breitner, Andres Löh, Alejandro Serrano and Wouter Swierstra.
+        We are starting a new Haskell-focused podcast where we interview guests from the Haskell community. The hosts are Niki Vazou, Joachim Breitner, Andres Löh, Alejandro Serrano and Wouter Swierstra. In this teaser episode, we introduce ourselves. The first regular episode will appear very soon.
       </p>
-
-      <p> The first episode is coming soon! </p>
-
+      <div id="buzzsprout-small-player-1817535"></div><script type="text/javascript" charset="utf-8" src="https://www.buzzsprout.com/1817535.js?container_id=buzzsprout-small-player-1817535&player=small"></script>
+      <p>
+        The music used is "Blue Lambda" by <a href="https://www.donyaquick.com/">Donya Quick</a>.
+        Many thanks to Donya for giving us permission to use this track for our podcast.
+      </p>
+    </div>
   </div>
-
-
 </div>
 
   </div>

--- a/site/podcast/index.html
+++ b/site/podcast/index.html
@@ -36,18 +36,18 @@
   </div>
 
 
-<div class="max-w-screen-md mx-auto grid gap-8">
-
-
-  <div class="bg-gray-100 px-6 sm:px-12 space-y-4 py-12">
-
+<div class="max-w-screen-xl mx-auto">
+  <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-12 lg:py-24">
+    <h2 class="text-center text-2xl-4xl font-normal">Episode 0: Teaser</h2>
+    <div class="mt-8  space-y-8 max-w-2xl mx-auto">
       <p>
-      		We are starting a new Haskell-focused podcast where we interview guests from the Haskell community. The hosts are Niki Vazou, Joachim Breitner, Andres Löh, Alejandro Serrano and Wouter Swierstra.
+        We are starting a new Haskell-focused podcast where we interview guests from the Haskell community. The hosts are Niki Vazou, Joachim Breitner, Andres Löh, Alejandro Serrano and Wouter Swierstra. In this teaser episode, we introduce ourselves. The first regular episode will appear very soon.
       </p>
-
-      <p> The first episode is coming soon! </p>
-
+      <div id='buzzsprout-small-player-1817535'></div><script type='text/javascript' charset='utf-8' src='https://www.buzzsprout.com/1817535.js?container_id=buzzsprout-small-player-1817535&player=small'></script>
+      <p>
+        The music used is "Blue Lambda" by <a href="https://www.donyaquick.com/">Donya Quick</a>.
+        Many thanks to Donya for giving us permission to use this track for our podcast.
+      </p>
+    </div>
   </div>
-
-
 </div>


### PR DESCRIPTION
Adds the teaser episode of the Haskell Interlude.

Please don't merge just yet.

This is how the podcast page looks after this change on my browser:

![Selection_022](https://user-images.githubusercontent.com/293191/125443389-3cf52dfe-6788-4e19-881a-1d0d1793e485.png)


