### PR TITLE
Fix contact us link and logo for subpages

### DIFF
--- a/site/templates/footer.html
+++ b/site/templates/footer.html
@@ -40,7 +40,7 @@
       <div class="lg:flex space-y-4 lg:gap-2 lg:flex-grow lg:space-y-0">
         <div class="font-medium mt-1">To learn more about the Haskell Foundation </div>
         <div class="ml-2">
-          <a href="./contact" class="arrow-link light">>> contact us</a>
+          <a href="/contact" class="arrow-link light">>> contact us</a>
         </div>
       </div>
 
@@ -53,7 +53,7 @@
 
     <div class="flex flex-row">
       <div class="mt-16 flex flex-col text-center flex-grow lg:flex-row lg:space-x-8 lg:space-y-0">
-        <img src="./static/images/haskell-foundation-logo-gray.svg" class="h-8" />
+        <img src="/static/images/haskell-foundation-logo-gray.svg" class="h-8" />
         <div class="font-medium">2021 © Haskell Foundation</div>
       </div>
 


### PR DESCRIPTION
When you navigate to a subpage like say, `https://haskell.foundation/projects/`, the footer contact us link is invalid as it points to `/projects/contact` as it uses the relative link format of `./contact`. Same was the case for the footer logo.