### PR TITLE
Set z-index of nav menus to avoid overlap with other content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ _site/
 # Node
 node_modules*
 package-lock*
+
+# Cabal
+dist-newstyle/

--- a/docs/affiliates/about/index.html
+++ b/docs/affiliates/about/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../news">
                   News

--- a/docs/affiliates/index.html
+++ b/docs/affiliates/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/board-nominations/index.html
+++ b/docs/board-nominations/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/donations/index.html
+++ b/docs/donations/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/guidelines-for-respectful-communication/index.html
+++ b/docs/guidelines-for-respectful-communication/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="./who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="./who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="./affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="./affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="./news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="./news">
                   News

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/news/press/index.html
+++ b/docs/news/press/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../news">
                   News

--- a/docs/podcast/index.html
+++ b/docs/podcast/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/resources/index.html
+++ b/docs/resources/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/vision/index.html
+++ b/docs/vision/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/whitepaper/index.html
+++ b/docs/whitepaper/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/who-we-are/index.html
+++ b/docs/who-we-are/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../news">
                   News

--- a/docs/who-we-are/past-boards/index.html
+++ b/docs/who-we-are/past-boards/index.html
@@ -96,7 +96,7 @@
         <li class="relative">
           <a href="../../who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../who-we-are">
                   Current Board
@@ -131,7 +131,7 @@
         <li class="relative">
           <a href="../../affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../affiliates">
                   Affiliates
@@ -148,7 +148,7 @@
        <li class="relative">
           <a href="../../news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="../../news">
                   News

--- a/site/templates/nav.html
+++ b/site/templates/nav.html
@@ -14,7 +14,7 @@
         <li class="relative">
           <a href="/who-we-are" id="who-we-are-nav-item">About</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="who-we-are-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="who-we-are-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="/who-we-are">
                   Current Board
@@ -49,7 +49,7 @@
         <li class="relative">
           <a href="/affiliates" id="affiliates-nav-item">Affiliates</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="affiliates-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="affiliates-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="/affiliates">
                   Affiliates
@@ -66,7 +66,7 @@
        <li class="relative">
           <a href="/news" id="news-nav-item">News and Info</a>
 
-            <div class="pt-2 absolute top-full w-44 bg-white shadow-md hidden" id="news-nav-item-menu">
+            <div class="pt-2 absolute top-full w-44 bg-white shadow-md z-10 hidden" id="news-nav-item-menu">
 
                 <a class="block p-4 border-t-2 hover:bg-gray-50 cursor-pointer" href="/news">
                   News


### PR DESCRIPTION
This fixes the following issue with the nav menus illustrated by a screenshot:

![Screenshot from 2021-08-01 10-11-50](https://user-images.githubusercontent.com/2716069/127764654-45b4c1b5-1e11-48f7-b735-44c7677a11c8.png)

To see the issue in the currently deployed version, go to e.g. https://haskell.foundation/donations/, open the "News and Info" menu and try to open the "Resources" or "FAQ" from that menu. Notice it's almost impossible, because the menu is closed if you happen to hover over the corner thingy that ovelaps with the menu.

The fix is to set the z-index of the menus to 10 (which I'm doing here by using the z-10 css class from tailwind).

After this PR the menu is rendered in front of other content and doesn't have the "undesired closing" issue
![Screenshot from 2021-08-01 10-35-09](https://user-images.githubusercontent.com/2716069/127764780-ccf6f8b3-a7c0-417d-bde9-ca01114387cd.png)
