### PR TITLE
Fix who we are pages.

### DIFF
--- a/docs/who-we-are/index.html
+++ b/docs/who-we-are/index.html
@@ -244,7 +244,7 @@
 Andrew was drawn to Haskell in 2015 as the best solution to solve the truly difficult problems in computer science. Most recently he was a Haskell developer and engineering manager at SimSpace Corp., working on software for cybersecurity readiness training and testing. He is extremely excited about serving the community, and looks forward to working with everyone to address pain points and build on the language’s strengths.
           </p>
           <div>
-            <a class="arrow-link" href="mailto">>> andrew@haskell.foundation</a>
+            <a class="arrow-link" href="mailto:andrew@haskell.foundation">>> andrew@haskell.foundation</a>
           </div>
         </div>
 
@@ -263,7 +263,7 @@ Andrew was drawn to Haskell in 2015 as the best solution to solve the truly diff
 Emily has since developed a proclivity for OSS and community contributions, authoring or maintaining many well-known Haskell packages, contributing to Core Libraries and Haskell.org as a board member, and serving the Haskell Foundation as its first Working Group Chair. She looks forward to seeing Haskell flourish, and building some great tech that will make everyone’s Haskell experience that much better.
           </p>
           <div>
-            <a class="arrow-link" href="mailto">>> emily@haskell.foundation</a>
+            <a class="arrow-link" href="mailto:emily@haskell.foundation">>> emily@haskell.foundation</a>
           </div>
         </div>
    </div>
@@ -301,7 +301,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> rae@richarde.dev</a>
+          <a class="arrow-link" href="mailto:rae@richarde.dev">>> rae@richarde.dev</a>
         </div>
       </div>
 
@@ -345,7 +345,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> michael@snoyman.com</a>
+          <a class="arrow-link" href="mailto:michael@snoyman.com">>> michael@snoyman.com</a>
         </div>
       </div>
 
@@ -367,7 +367,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> hecate@haskell.foundation</a>
+          <a class="arrow-link" href="mailto:hecate@haskell.foundation">>> hecate@haskell.foundation</a>
         </div>
       </div>
 
@@ -389,7 +389,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> ryan@trinkle.org</a>
+          <a class="arrow-link" href="mailto:ryan@trinkle.org">>> ryan@trinkle.org</a>
         </div>
       </div>
 
@@ -411,7 +411,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> dreixel@gmail.com</a>
+          <a class="arrow-link" href="mailto:dreixel@gmail.com">>> dreixel@gmail.com</a>
         </div>
       </div>
 
@@ -427,7 +427,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
              Simon is a researcher at Microsoft Research in Cambridge, England, where he started in Sept 1998. He’s also an Honorary Professor of the Computing Science Department at Glasgow University, where he was a professor during 1990-1998.  Simon is interested in the design, implementation, and application of lazy functional languages. He was one of the original designers of Haskell, and much of his work is focused around the Glasgow Haskell Compiler and its ramifications. Simon is also chair of Computing at School, the group at the epicentre of the reform of the national curriculum for Computing in England. Computer science is now a foundational subject, alongside maths and natural science, that every child learns from primary school onwards.
           </p>
           <div>
-            <a class="arrow-link" href="mailto">>> simonpj@microsoft.com</a>
+            <a class="arrow-link" href="mailto:simonpj@microsoft.com">>> simonpj@microsoft.com</a>
           </div>
         </div>
 
@@ -449,7 +449,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> chris@chrisdornan.com</a>
+            <a class="arrow-link" href="mailto:chris@chrisdornan.com">>> chris@chrisdornan.com</a>
           </div>
         </div>
 
@@ -471,7 +471,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> acopton+hf@gmail.com</a>
+            <a class="arrow-link" href="mailto:acopton+hf@gmail.com">>> acopton+hf@gmail.com</a>
           </div>
         </div>
 
@@ -493,7 +493,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> ekmett@gmail.com</a>
+            <a class="arrow-link" href="mailto:ekmett@gmail.com">>> ekmett@gmail.com</a>
           </div>
         </div>
 
@@ -515,7 +515,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> scott@flipstone.com</a>
+            <a class="arrow-link" href="mailto:scott@flipstone.com">>> scott@flipstone.com</a>
           </div>
         </div>
 
@@ -537,7 +537,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> wendy.devolder@haskell.foundation</a>
+            <a class="arrow-link" href="mailto:wendy.devolder@haskell.foundation">>> wendy.devolder@haskell.foundation</a>
           </div>
         </div>
 
@@ -559,7 +559,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> andrew.lelechenko@gmail.com</a>
+            <a class="arrow-link" href="mailto:andrew.lelechenko@gmail.com">>> andrew.lelechenko@gmail.com</a>
           </div>
         </div>
 
@@ -581,7 +581,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> niki.vazou@imdea.org</a>
+            <a class="arrow-link" href="mailto:niki.vazou@imdea.org">>> niki.vazou@imdea.org</a>
           </div>
         </div>
     </div>

--- a/docs/who-we-are/past-boards/index.html
+++ b/docs/who-we-are/past-boards/index.html
@@ -240,15 +240,6 @@
         <p>
           Simon is a researcher at Microsoft Research in Cambridge, England. He started there in Sept 1998. He’s also an Honorary Professor of the Computing Science Department at Glasgow University, where he was a professor during 1990-1998. Simon is married to Dorothy, a priest in the Church of England. They have six children. Simon is interested in the design, implementation, and application of lazy functional languages. In practical terms, that means he spends a most of my time on the design and implementation of the language Haskell. In particular, much of his work is focused around the Glasgow Haskell Compiler, and its ramifications. Simon is also chair of Computing at School, the group at the epicentre of the reform of the national curriculum for Computing in England. Computer science is now a foundational subject, alongside maths and natural science, that every child learns from primary school onwards.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -262,15 +253,6 @@
         <p>
           Chris has been interested in Haskell since the early reports and wrote the original Alex package in the 1990s. In the late nineties Chris taught Haskell to undergraduates in UCC (Cork) and in the noughties used Haskell tools to develop key aspects of the ARMv7 architecture. Since 2013 Chris has been chief Engineer for IRIS Connect where he has overseen the development of the new IRIS Connect video platform which makes extensive use of Haskell in the back end.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -284,15 +266,6 @@
         <p>
           Gabriele is Professor of Software Technology in the Department of Information and Computing Sciences. Her research focuses on how programming languages can be used to improve the quality of software. Conventional software testing is very important, but can’t guarantee the absence of errors. She is addressing this problem in her research on developing and using programming languages that are based on mathematical theory, so we can prove that a program will work in all scenarios. Call it ‘correctness by construction’. The real world significance is obvious: it saves a lot of time and it eliminates errors, so which company wouldn’t want it?
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -306,15 +279,6 @@
         <p>
           Jasper is a Principal Engineer at Fugue, a cloud security startup. He has been deeply involved in the Haskell community for over ten years, contributing as open source maintainer as well as community organizer, with efforts like ZuriHac and Summer of Haskell. He currently chairs the Haskell.org committee.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -328,15 +292,6 @@
         <p>
           Edward is a researcher focused on AI safety at the Machine Intelligence Research Institute. He also sits on the board of the Topos Institute, promoting category theory in industry as a tool for exchanging ideas. Outside of Haskell he's worked on graphics and special effects, telecommunications, finance, linguistics, and once helped Taiwan point a big RADAR at China. Edward found Haskell in 2006 and at the time mistakenly believed all Haskellers were thoroughly fluent in category theory, so he started blogging to this imaginary audience. A few years later his work on lenses provided a more practical impetus for more folks to learn some of these ideas, closing the circle. He currently maintains well over a hundred Haskell libraries covering a rather wide swathe of topics and isn't entirely sure how he backed himself in that position.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -350,15 +305,6 @@
         <p>
           Stephanie Weirich is the ENIAC President's Distinguished Professor of Computer and Information Science at the University of Pennsylvania. Her research areas include functional programming, type systems, machine-assisted theorem proving and dependent types. She and her students have made significant contributions to the design of the type system of the Glasgow Haskell Compiler. Dr. Weirich was recognized by the SIGPLAN Milner Young Researcher award (2016), a Microsoft Outstanding collaborator award, and a most influential ICFP paper award (awarded in 2016, for 2006). She has served as the general chair of ICFP 2020 and as the program chair of POPL 2018, ICFP 2010, and the 2009 Haskell Symposium.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -372,15 +318,6 @@
         <p>
           Simon Marlow is a Software Engineer at Facebook in London. He has previously worked on Haxl, a Haskell-based domain-specific language that is used by the teams fighting abuse on Facebook, and he is currently working on Glean, a system to store and query facts about source code at scale. Simon is a co-author of the Glasgow Haskell Compiler, author of the book “Parallel and Concurrent Programming in Haskell”, and has a string of research publications in functional programming, language design, compilers, and language implementation.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -394,15 +331,6 @@
         <p>
           Lennart has been using and implementing Haskell in various roles for the last 30 years. He currently works for Epic Games.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
   </div>
 </div>

--- a/site/who-we-are/index.html
+++ b/site/who-we-are/index.html
@@ -61,7 +61,7 @@
 Andrew was drawn to Haskell in 2015 as the best solution to solve the truly difficult problems in computer science. Most recently he was a Haskell developer and engineering manager at SimSpace Corp., working on software for cybersecurity readiness training and testing. He is extremely excited about serving the community, and looks forward to working with everyone to address pain points and build on the language’s strengths.
           </p>
           <div>
-            <a class="arrow-link" href="mailto">>> andrew@haskell.foundation</a>
+            <a class="arrow-link" href="mailto:andrew@haskell.foundation">>> andrew@haskell.foundation</a>
           </div>
         </div>
 
@@ -80,7 +80,7 @@ Andrew was drawn to Haskell in 2015 as the best solution to solve the truly diff
 Emily has since developed a proclivity for OSS and community contributions, authoring or maintaining many well-known Haskell packages, contributing to Core Libraries and Haskell.org as a board member, and serving the Haskell Foundation as its first Working Group Chair. She looks forward to seeing Haskell flourish, and building some great tech that will make everyone’s Haskell experience that much better.
           </p>
           <div>
-            <a class="arrow-link" href="mailto">>> emily@haskell.foundation</a>
+            <a class="arrow-link" href="mailto:emily@haskell.foundation">>> emily@haskell.foundation</a>
           </div>
         </div>
    </div>
@@ -118,7 +118,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> rae@richarde.dev</a>
+          <a class="arrow-link" href="mailto:rae@richarde.dev">>> rae@richarde.dev</a>
         </div>
       </div>
 
@@ -162,7 +162,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> michael@snoyman.com</a>
+          <a class="arrow-link" href="mailto:michael@snoyman.com">>> michael@snoyman.com</a>
         </div>
       </div>
 
@@ -184,7 +184,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> hecate@haskell.foundation</a>
+          <a class="arrow-link" href="mailto:hecate@haskell.foundation">>> hecate@haskell.foundation</a>
         </div>
       </div>
 
@@ -206,7 +206,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> ryan@trinkle.org</a>
+          <a class="arrow-link" href="mailto:ryan@trinkle.org">>> ryan@trinkle.org</a>
         </div>
       </div>
 
@@ -228,7 +228,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </p>
         </div>
         <div>
-          <a class="arrow-link" href="mailto">>> dreixel@gmail.com</a>
+          <a class="arrow-link" href="mailto:dreixel@gmail.com">>> dreixel@gmail.com</a>
         </div>
       </div>
 
@@ -244,7 +244,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
              Simon is a researcher at Microsoft Research in Cambridge, England, where he started in Sept 1998. He’s also an Honorary Professor of the Computing Science Department at Glasgow University, where he was a professor during 1990-1998.  Simon is interested in the design, implementation, and application of lazy functional languages. He was one of the original designers of Haskell, and much of his work is focused around the Glasgow Haskell Compiler and its ramifications. Simon is also chair of Computing at School, the group at the epicentre of the reform of the national curriculum for Computing in England. Computer science is now a foundational subject, alongside maths and natural science, that every child learns from primary school onwards.
           </p>
           <div>
-            <a class="arrow-link" href="mailto">>> simonpj@microsoft.com</a>
+            <a class="arrow-link" href="mailto:simonpj@microsoft.com">>> simonpj@microsoft.com</a>
           </div>
         </div>
 
@@ -266,7 +266,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> chris@chrisdornan.com</a>
+            <a class="arrow-link" href="mailto:chris@chrisdornan.com">>> chris@chrisdornan.com</a>
           </div>
         </div>
 
@@ -288,7 +288,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> acopton+hf@gmail.com</a>
+            <a class="arrow-link" href="mailto:acopton+hf@gmail.com">>> acopton+hf@gmail.com</a>
           </div>
         </div>
 
@@ -310,7 +310,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> ekmett@gmail.com</a>
+            <a class="arrow-link" href="mailto:ekmett@gmail.com">>> ekmett@gmail.com</a>
           </div>
         </div>
 
@@ -332,7 +332,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> scott@flipstone.com</a>
+            <a class="arrow-link" href="mailto:scott@flipstone.com">>> scott@flipstone.com</a>
           </div>
         </div>
 
@@ -354,7 +354,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> wendy.devolder@haskell.foundation</a>
+            <a class="arrow-link" href="mailto:wendy.devolder@haskell.foundation">>> wendy.devolder@haskell.foundation</a>
           </div>
         </div>
 
@@ -376,7 +376,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> andrew.lelechenko@gmail.com</a>
+            <a class="arrow-link" href="mailto:andrew.lelechenko@gmail.com">>> andrew.lelechenko@gmail.com</a>
           </div>
         </div>
 
@@ -398,7 +398,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
             </p>
           </div>
           <div>
-            <a class="arrow-link" href="mailto">>> niki.vazou@imdea.org</a>
+            <a class="arrow-link" href="mailto:niki.vazou@imdea.org">>> niki.vazou@imdea.org</a>
           </div>
         </div>
     </div>

--- a/site/who-we-are/past-boards/index.html
+++ b/site/who-we-are/past-boards/index.html
@@ -57,15 +57,6 @@
         <p>
           Simon is a researcher at Microsoft Research in Cambridge, England. He started there in Sept 1998. He’s also an Honorary Professor of the Computing Science Department at Glasgow University, where he was a professor during 1990-1998. Simon is married to Dorothy, a priest in the Church of England. They have six children. Simon is interested in the design, implementation, and application of lazy functional languages. In practical terms, that means he spends a most of my time on the design and implementation of the language Haskell. In particular, much of his work is focused around the Glasgow Haskell Compiler, and its ramifications. Simon is also chair of Computing at School, the group at the epicentre of the reform of the national curriculum for Computing in England. Computer science is now a foundational subject, alongside maths and natural science, that every child learns from primary school onwards.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -79,15 +70,6 @@
         <p>
           Chris has been interested in Haskell since the early reports and wrote the original Alex package in the 1990s. In the late nineties Chris taught Haskell to undergraduates in UCC (Cork) and in the noughties used Haskell tools to develop key aspects of the ARMv7 architecture. Since 2013 Chris has been chief Engineer for IRIS Connect where he has overseen the development of the new IRIS Connect video platform which makes extensive use of Haskell in the back end.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -101,15 +83,6 @@
         <p>
           Gabriele is Professor of Software Technology in the Department of Information and Computing Sciences. Her research focuses on how programming languages can be used to improve the quality of software. Conventional software testing is very important, but can’t guarantee the absence of errors. She is addressing this problem in her research on developing and using programming languages that are based on mathematical theory, so we can prove that a program will work in all scenarios. Call it ‘correctness by construction’. The real world significance is obvious: it saves a lot of time and it eliminates errors, so which company wouldn’t want it?
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -123,15 +96,6 @@
         <p>
           Jasper is a Principal Engineer at Fugue, a cloud security startup. He has been deeply involved in the Haskell community for over ten years, contributing as open source maintainer as well as community organizer, with efforts like ZuriHac and Summer of Haskell. He currently chairs the Haskell.org committee.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -145,15 +109,6 @@
         <p>
           Edward is a researcher focused on AI safety at the Machine Intelligence Research Institute. He also sits on the board of the Topos Institute, promoting category theory in industry as a tool for exchanging ideas. Outside of Haskell he's worked on graphics and special effects, telecommunications, finance, linguistics, and once helped Taiwan point a big RADAR at China. Edward found Haskell in 2006 and at the time mistakenly believed all Haskellers were thoroughly fluent in category theory, so he started blogging to this imaginary audience. A few years later his work on lenses provided a more practical impetus for more folks to learn some of these ideas, closing the circle. He currently maintains well over a hundred Haskell libraries covering a rather wide swathe of topics and isn't entirely sure how he backed himself in that position.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -167,15 +122,6 @@
         <p>
           Stephanie Weirich is the ENIAC President's Distinguished Professor of Computer and Information Science at the University of Pennsylvania. Her research areas include functional programming, type systems, machine-assisted theorem proving and dependent types. She and her students have made significant contributions to the design of the type system of the Glasgow Haskell Compiler. Dr. Weirich was recognized by the SIGPLAN Milner Young Researcher award (2016), a Microsoft Outstanding collaborator award, and a most influential ICFP paper award (awarded in 2016, for 2006). She has served as the general chair of ICFP 2020 and as the program chair of POPL 2018, ICFP 2010, and the 2009 Haskell Symposium.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -189,15 +135,6 @@
         <p>
           Simon Marlow is a Software Engineer at Facebook in London. He has previously worked on Haxl, a Haskell-based domain-specific language that is used by the teams fighting abuse on Facebook, and he is currently working on Glean, a system to store and query facts about source code at scale. Simon is a co-author of the Glasgow Haskell Compiler, author of the book “Parallel and Concurrent Programming in Haskell”, and has a string of research publications in functional programming, language design, compilers, and language implementation.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
 
       <div class="border border-gray-300 rounded py-8 px-6 sm:px-12 md:px-6 lg:px-12 space-y-6">
@@ -211,15 +148,6 @@
         <p>
           Lennart has been using and implementing Haskell in various roles for the last 30 years. He currently works for Epic Games.
         </p>
-        <div>
-          <div class="font-bold text-gray-600">Committees</div>
-          <p>
-            Committee One, Committee Two
-          </p>
-        </div>
-        <div>
-          <a class="arrow-link" href="mailto">>> email@address.com</a>
-        </div>
       </div>
   </div>
 </div>


### PR DESCRIPTION
Fix email links for current exec team and board, remove stuff not filled in for interim. Close #76