### PR TITLE
Mildy restyle podcast page

### DIFF
--- a/podcast/1.markdown
+++ b/podcast/1.markdown
@@ -15,7 +15,7 @@ published: 2021-08-09
 * [ghcup](https://gitlab.haskell.org/haskell/ghcup-hs)
 * [Chocolatey GHC packages](https://community.chocolatey.org/profiles/Phyx)
 * [Haskell Foundation on the Haskell Discourse](https://discourse.haskell.org/c/haskell-foundation/)
-* [Contact page of the Haskell Foundation including Slack invite link](https://haskell.foundation/contact/)
+* [Contact page of the Haskell Foundation](https://haskell.foundation/contact/) (including Slack invite link)
 * [YourKit](https://www.yourkit.com/)
 * [Wingman tactics plugin for Haskell Language Server](https://haskellwingman.dev/)
 * [Simple Haskell Initiative](https://simplehaskell.org/)

--- a/templates/podcast/list.html
+++ b/templates/podcast/list.html
@@ -1,92 +1,93 @@
-
-
-
-  <div class="max-w-screen-xl mx-auto py-16 md:py-24">
-    <div class="sm:px-6 lg:px-16">
-      <div class="relative">
-  <div class="absolute top-0 left-0 border-t border-l border-purple-50 h-10 md:h-20 w-10 md:w-20">
-    <div class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-100 h-10 md:h-20 w-10 md:w-20">
-      <div class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-200 h-10 md:h-20 w-10 md:w-20">
-        <div class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-300 h-10 md:h-20 w-10 md:w-20">
-          <div class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-400 h-10 md:h-20 w-10 md:w-20">
-            <div class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-500 h-10 md:h-20 w-10 md:w-20"></div>
+<div class="max-w-screen-xl mx-auto py-16 md:py-24">
+  <div class="sm:px-6 lg:px-16">
+    <div class="relative">
+      <div class="absolute top-0 left-0 border-t border-l border-purple-50 h-10 md:h-20 w-10 md:w-20">
+        <div
+          class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-100 h-10 md:h-20 w-10 md:w-20">
+          <div
+            class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-200 h-10 md:h-20 w-10 md:w-20">
+            <div
+              class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-300 h-10 md:h-20 w-10 md:w-20">
+              <div
+                class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-400 h-10 md:h-20 w-10 md:w-20">
+                <div
+                  class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-500 h-10 md:h-20 w-10 md:w-20">
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="absolute top-0 right-0 border-t border-r border-purple-50 h-10 md:h-20 w-10 md:w-20">
+        <div
+          class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-100 h-10 md:h-20 w-10 md:w-20">
+          <div
+            class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-200 h-10 md:h-20 w-10 md:w-20">
+            <div
+              class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-300 h-10 md:h-20 w-10 md:w-20">
+              <div
+                class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-400 h-10 md:h-20 w-10 md:w-20">
+                <div
+                  class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-500 h-10 md:h-20 w-10 md:w-20">
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-  <div class="absolute top-0 right-0 border-t border-r border-purple-50 h-10 md:h-20 w-10 md:w-20">
-    <div class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-100 h-10 md:h-20 w-10 md:w-20">
-      <div class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-200 h-10 md:h-20 w-10 md:w-20">
-        <div class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-300 h-10 md:h-20 w-10 md:w-20">
-          <div class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-400 h-10 md:h-20 w-10 md:w-20">
-            <div class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-500 h-10 md:h-20 w-10 md:w-20"></div>
-          </div>
+
+  <div class="text-center pt-12 md:pt-20 px-12 sm:px-16 md:px-24 lg:px-36 ">
+     <h1 class="text-2xl-5xl">The Haskell Interlude</h1>
+  </div>
+
+  <div class="mt-16 md:mt-24">
+    <div class="xl:max-w-screen-xl mx-auto md:px-12 lg:px-16">
+      <div class="bg-gray-800 shadow-lg shadow-xl shadow-md shadow-sm px-6 sm:px-12 md:px-12 lg:px-16 py-16 md:py-20">
+        <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
+         The Haskell Interlude is Haskell-focused podcast where we interview guests from the Haskell community. The hosts are Niki Vazou, Joachim Breitner, Andres Löh, Alejandro Serrano and Wouter Swierstra.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-16 md:mt-24">
+    <div class="max-w-screen-xl mx-auto grid gap-8 lg:grid-cols-2 md:px-12">
+      $for(episodes)$
+        <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-12 lg:py-24">
+          <h2 class="text-center text-2xl-4xl font-normal"><b>$episode$</b> – $title$</h2>
+          <div class="mt-8  space-y-8 max-w-2xl mx-auto">
+            $if(recorded)$
+             <p><em>Recorded $recorded$. Published $published$.</em></p>
+            $endif$
+            <p>$description$</p>
+            <div id="buzzsprout-player-$buzzsproutId$"></div>
+            <script src="https://www.buzzsprout.com/1817535/$buzzsproutId$-$buzzsproudName$.js?container_id=buzzsprout-player-$buzzsproutId$&player=small" type="text/javascript" charset="utf-8"></script>
+            <div class="mt-4">
+              <a class="arrow-link" href="/podcast/$episode$/transcript/">>> Full transcript</a>
+            </div>
+            <div class="uppercase font-medium text-gray-500 pt-4">Selected links</div>
+              $body$
+           </div>
         </div>
+      $endfor$
+    </div>
+  </div>
+
+  <div class="mt-16 md:mt-24">
+    <div class="xl:max-w-screen-xl mx-auto md:px-12 lg:px-16">
+      <div class="bg-gray-800 shadow-lg shadow-xl shadow-md shadow-sm px-6 sm:px-12 md:px-12 lg:px-16 py-16 md:py-20">
+        <h2 class="text-gray-50 font-normal text-3xl-4xl text-center">Acknowledgements</h2>
+        <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
+          The music used is "Blue Lambda" by <a href="https://www.donyaquick.com/">Donya Quick</a>.<br/>
+          Many thanks to Donya for giving us permission to use this track for our podcast.
+        </p>
+        <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
+          We are very grateful to Alp Mestanogullar for his help with editing the episodes.
+        </p>
       </div>
     </div>
   </div>
-</div>
-
-    </div>
-
-<div class="text-center pt-12 md:pt-20 px-12 sm:px-16 md:px-24 lg:px-36 ">
-   <h1 class="text-2xl-5xl">The Haskell Interlude</h1>
-</div>
-</div>
-
-<div class="max-w-screen-xl mx-auto">
-  <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-12 lg:py-24">
-    <div class="mt-8  space-y-8 max-w-2xl mx-auto">
-      <p>
-        The Haskell Interlude is Haskell-focused podcast where we interview guests from the Haskell community. The hosts are Niki Vazou, Joachim Breitner, Andres Löh, Alejandro Serrano and Wouter Swierstra.
-      </p>
-      <div class="mt-4">
-        <a class="arrow-link" href="https://feeds.buzzsprout.com/1817535.rss">>> RSS feed</a>
-      </div>
-    </div>
-  </div>
-
-  $for(episodes)$
-  <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-12 lg:py-24">
-    <h2 class="text-center text-2xl-4xl font-normal">Episode $episode$: $title$</h2>
-    <div class="mt-8  space-y-8 max-w-2xl mx-auto">
-      $if(recorded)$
-      <p>
-        <em>Recorded $recorded$. Published $published$.</em>
-      </p>
-      $endif$
-      <p>
-        $description$
-      </p>
-      <div id="buzzsprout-player-$buzzsproutId$"></div>
-<script src="https://www.buzzsprout.com/1817535/$buzzsproutId$-$buzzsproudName$.js?container_id=buzzsprout-player-$buzzsproutId$&player=small" type="text/javascript" charset="utf-8"></script>
-      <div class="mt-4">
-        <a class="arrow-link" href="/podcast/$episode$/transcript/">>> Full transcript</a>
-      </div>
-      <div class="uppercase font-medium text-gray-500 pt-4">Selected links</div>
-      $body$
-    </div>
-  </div>
-  $endfor$
-
-</div>
-
-<div class="mt-16 md:mt-24">
-
-  <div class="xl:max-w-screen-xl mx-auto md:px-12 lg:px-16">
-    <div class="bg-gray-800 shadow-lg shadow-xl shadow-md shadow-sm px-6 sm:px-12 md:px-12 lg:px-16 py-16 md:py-20">
-      <h2 class="text-gray-50 font-normal text-3xl-4xl text-center">Acknowledgements</h2>
-      <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
-        The music used is "Blue Lambda" by <a href="https://www.donyaquick.com/">Donya Quick</a>.<br/>
-        Many thanks to Donya for giving us permission to use this track for our podcast.
-      </p>
-      <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
-        We are very grateful to Alp Mestanogullar for his help with editing the episodes.
-      </p>
-    </div>
-  </div>
-
-</div>
 
 </div>


### PR DESCRIPTION
* Use same black box for intro text as the projects page. I don't find
  it very pretty, but it's consistent.

* Use separate grey boxes for each episode. Makes it easier to visually
  find the episodes.

* On wide screens, allow two episodes next to each other. We don't have
  that much text there, but a narrow list of links, so this looks
  better.

* Don't say “Episode” in the title for the box. It’s rather repetitive
  and distracts from the important information (the guest’s name).
  So now it’s just “*2* – Lennart Augustsson”

* Consistently indented the HTML template file

* Changed “selected links” to “related links”

It seems that `assets/css/main.css` is a generated file, so I did not
make tweaks that requires editing the CSS.