### PR TITLE
Fix slack invite link.

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -127,7 +127,7 @@ title: Contacting the Haskell Foundation
     </p>
     <div class="flex flex-col sm:flex-row justify-around md:flex-col lg:flex-row">
       <div class="mt-8 mx-3 center">
-        <a class="arrow-link" href="https://join.slack.com/t/haskell-foundation/shared_invite/zt-mjh76fw0-CEjg2NbyVE8rVQDvR~0F4A">>> Slack Invite</a>
+        <a class="arrow-link" href="https://join.slack.com/t/haskell-foundation/shared_invite/zt-z45o9x38-8L55P27r12YO0YeEufcO2w">>> Slack Invite</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Multiple reports the link was broken, and that this one works.