### PR TITLE
Add Servant and the Cryptography Group to the Affiliates page

### DIFF
--- a/affiliates/cryptographygroup.markdown
+++ b/affiliates/cryptographygroup.markdown
@@ -1,0 +1,5 @@
+---
+title: Haskell Cryptography Group
+externalUrl: https://github.com/haskell-cryptography
+status: affiliated
+---

--- a/affiliates/servant.markdown
+++ b/affiliates/servant.markdown
@@ -1,0 +1,5 @@
+---
+title: Servant Web Framework
+externalUrl: https://haskell-servant.github.io/
+status: affiliated
+---


### PR DESCRIPTION
This PR adds Servant & the Cryptography Group to the list of affiliates.

For reference:

* https://github.com/haskell-cryptography/governance/issues/3

* https://github.com/haskell-servant/haskell-servant.github.io/issues/65

Once the core members of these groups have expressed their votes, this PR will be marked as ready.