### PR TITLE
projects: delete HF slack link

### DIFF
--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -49,9 +49,8 @@ title: Projects
         <h2 class="text-gray-50 font-normal text-3xl-4xl text-center">Volunteering</h2>
         <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
           We are always looking for help on our projects. If you would like to volunteer, please reach out to us at <a
-            href="mailto:volunteer@haskell.foundation">volunteer@haskell.foundation</a>, or join the <a
-            href="https://join.slack.com/t/haskell-foundation/shared_invite/zt-mjh76fw0-CEjg2NbyVE8rVQDvR~0F4A">Haskell
-            Foundation Slack</a>. If you have a proposal, we'd love to hear it!
+            href="mailto:volunteer@haskell.foundation">volunteer@haskell.foundation</a>.
+          If you have a proposal, we'd love to hear it!
         </p>
       </div>
     </div>


### PR DESCRIPTION
The link does not let anyone without HF email account in, so let's drop it to prevent confusion.