### PR TITLE
Add Mastodon to social media links in footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -59,6 +59,7 @@
         <a href="https://twitter.com/haskellfound" target="_blank" class="text-4xl block"><span class="fab fa-twitter"></span></a>
         <a href="https://www.linkedin.com/company/haskell-foundation-inc" target="_blank" class="text-4xl block"><span class="fab fa-linkedin-in"></span></a>
         <a href="https://discourse.haskell.org/c/haskell-foundation/11" target="_blank" class="text-4xl block"><span class="fab fa-discourse"></span></a>
+        <a rel="me" href="https://mastodon.social/@haskell_foundation" target="_blank" class="text-4xl block"><span class="fab fa-mastodon"></span></a>
       </div>
     </div>
 


### PR DESCRIPTION
The `rel` attribute is there to verify our account on Mastodon.