### PR TITLE
Prominently display board election on homepage

### DIFF
--- a/news/2023-02-23/board-vacancies.markdown
+++ b/news/2023-02-23/board-vacancies.markdown
@@ -1,0 +1,8 @@
+---
+title: Board Vacancies
+link: https://discourse.haskell.org/t/2023-call-for-nominations-for-the-haskell-foundation/5803
+---
+
+The Haskell Foundation [is seeking four new members for the board](https://discourse.haskell.org/t/2023-call-for-nominations-for-the-haskell-foundation/5803). The Board provides the strategic leadership for the Foundation, and is the final decision-making body for everything the Foundation does. More specifically, it ensures that the Foundation is working toward achieving its mission, and it appoints and supervises senior members of Foundation staff.
+
+Nominations are due by March 1, 2023.

--- a/site.hs
+++ b/site.hs
@@ -1,6 +1,7 @@
 {-# Language ScopedTypeVariables #-}
 {-# Language OverloadedStrings #-}
 {-# Language ViewPatterns #-}
+{-# Language TypeApplications #-}
 
 import Hakyll
 import Data.List (sortOn)
@@ -213,10 +214,13 @@ main = hakyll $ do
         compile $ do
             sponsors <- buildBoilerplateCtx (Just "Haskell Foundation")
             podcastsCtx <- podcastCtx . take 1 . reverse . sortOn podcastOrd <$> loadAll ("podcast/*/index.markdown" .&&. hasVersion "raw")
+            careers <- loadAll @String "careers/*.markdown"
             careersCtx <- careersCtx . reverse <$> loadAll "careers/*.markdown"
+            announces  <- take 1 <$> (recentFirst =<< loadAll @String "news/*/**.markdown")
+            let announceCtx = announcementsCtx announces
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/homepage.html" (podcastsCtx <> careersCtx)
+                >>= loadAndApplyTemplate "templates/homepage.html" (podcastsCtx <> careersCtx <> announceCtx)
                 >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
@@ -400,6 +404,12 @@ hiringSponsorsCtx :: [Item String] -> Context String
 hiringSponsorsCtx sponsors =
     listField "hiringsponsors" defaultContext (filterMetadataField "careersUrl" sponsors) <>
     defaultContext
+
+-- Anouncements
+
+announcementsCtx :: [Item String] -> Context String
+announcementsCtx ads =
+  listField "announcements" defaultContext (pure ads)
 
 --------------------------------------------------------------------------------------------------------
 -- UTILS -----------------------------------------------------------------------------------------------

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -23,6 +23,12 @@
         $endfor$
         $endif$
 
+        $if(announcements)$
+        $for(announcements)$
+        $partial("templates/news/frontpage.html")$
+        $endfor$
+        $endif$
+
         $for(episodes)$
         <div class="bg-white border border-gray-300 rounded py-8 px-6 sm:px-12 text-center">
             <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-6 lg:py-24">

--- a/templates/news/frontpage.html
+++ b/templates/news/frontpage.html
@@ -1,0 +1,14 @@
+<div class="bg-white border border-gray-300 rounded py-8 px-6 sm:px-12 text-center">
+  <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-6 lg:py-24">
+    <div class="space-y-4">
+      <h2 class="text-center text-2xl-4xl font-normal">$title$</h2>
+      <p>$body$</p>
+
+      $if(link)$
+        <div class="mt-4">
+          <a class="arrow-link" href="$link$">&gt;&gt; Read more</a>
+        </div>
+      $endif$
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Enable the display of the latest news item on the front page, together with podcast episodes and open positions.

Add a news item that encourages applications for the open board seats.