### PR TITLE
Add opengraph tags to podcast pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,15 @@ jobs:
       - name: Build site executable
         run: stack build --system-ghc
 
+      - name: Build site
+        run:  stack exec --system-ghc site rebuild
+
       - name: Deploy
         # No deploy from pull requests
         if: ${{ github.event_name != 'pull_request' }}
         run: |
             git config user.name github-actions
             git config user.email github-actions@github.com
-            stack exec --system-ghc site rebuild
             git checkout main
             git pull --rebase
             # Overwrite existing files with new files

--- a/haskell-foundation.cabal
+++ b/haskell-foundation.cabal
@@ -8,5 +8,7 @@ executable site
   build-depends:    base == 4.*
                   , hakyll
                   , monadlist
+                  , pandoc
+                  , text
   ghc-options:      -threaded
   default-language: Haskell2010

--- a/templates/boilerplate.html
+++ b/templates/boilerplate.html
@@ -13,7 +13,6 @@
   <!-- other -->
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1" data-ssr="" name="viewport">
-  <title>$title$</title>
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code&family=Maven+Pro:wght@400;500;700&family=Playfair+Display:wght@400;600;800&display=swap" rel="stylesheet">
   <link href="/assets/fontawesome-free-5.15.2-web/css/all.css" rel="stylesheet">
@@ -35,6 +34,14 @@
         });
     }
   </script>
+
+  <!-- metadata -->
+  <title>$title$</title>
+  <meta property="og:title" content="$title$"></meta>
+  $if(description)$
+  <meta property="og:description" content="$description$"></meta>
+  $endif$
+
 </head>
 <body class="relative">
 


### PR DESCRIPTION
It annoyed me that linking to the podcast pages on social media, e.g. on https://discourse.haskell.org/t/haskell-interlude-episode-22-alejandro-russo/5886, does not produce a nice preview box. This PR should fix this, by including the opengraph title and description tags.

The description is taken from the first paragraph of the source markdown file.