### PR TITLE
Add infrastructure for events, plus the GHC contributors workshop

### DIFF
--- a/events/2023-ghc-development-workshop.markdown
+++ b/events/2023-ghc-development-workshop.markdown
@@ -1,0 +1,43 @@
+---
+title: 2023 GHC Contributors' Workshop
+published: 2023-03-01
+daterange: June 7-9, 2023
+status: active
+location: Rapperswil, Switzerland
+summary: A hands-on introduction to working on GHC, colocated with Zurihac 2023
+---
+
+
+We are excited to announce the **2023 GHC Contributors' Workshop, June 7-9 2023**, organized by the GHC developers, the Haskell Foundation, and the OST Eastern Switzerland University of Applied Sciences! This is a workshop for those who want to get started working on GHC, those who want to understand GHC's internals to better diagnose issues with their own code, and those who want to transfer lessons learned in GHC to other compilers. The primary aim of the workshop is to broaden the base of contributors to GHC.
+
+In this three-day event, held on the lakeside campus of OST in lovely Rapperswil, Switzerland, you can learn what you need to know in order to get started working on GHC, right from the core team itself. Because the workshop is immediately prior to [Zurihac 2023](https://zfoh.ch/zurihac2023/), there will be time to work on your project and ask questions.
+
+At this workshop, you can learn the ins and outs of working on GHC, including practical techniques for minimizing rebuilds and diagnosing compiler bugs. The fundamental concepts and idioms of key compiler subsystems will be presented, along with tips and tricks for understanding how they are working in a running compiler. This is a practical workshop: any theory presented will be in service of building things, and we expect that you will arrive with a checkout and build of the source tree ready to go.
+
+Additionally, the speakers will be available to answer questions and to provide mentorship during Zurihac itself, so this is a great opportunity to finish your first MR.
+
+We expect that participants already know Haskell and have worked on some form of programming language implementation in the past, whether as students, at work, or just for fun. Concepts such as parsing, type checking, unification, and code generation should be familiar, but we don't expect participants to already be experts.
+
+So far, Simon Peyton Jones has confirmed that he will present at the workshop. Watch this space for more presenters as we confirm them!
+
+Due to space constraints and to enable scholarships for student participants, there will be a fee for full on-site participation.
+Fees will be used to cover travel costs for presenters and students who don't have other funding to attend.
+The fee depends on participant category:
+
+ * _Enrolled students_ ($$40) are participants who are enrolled full-time at an educational institution. 
+
+ * _Individual professionals_ ($$400) are no longer students and are interested in working on GHC for their own purposes. 
+
+ * _Corporate participants_ ($$1200) are being paid by their employer to attend so that they can use the knowledge that they gain on the job. Corporate participants will have their company name on their name tag and their company will be listed on the event web page as a supporter of the event.
+ 
+All fees are in US dollars.
+We want the event to be as accessible as possible, given our limitations, so if the fee is a barrier to attending, please contact David Thrane Christiansen at [david@haskell.foundation](mailto:david@haskell.foundation) to discuss a reduced or waived fee—this goes for all three categories of participant.
+
+A certificate of completion will be available on advance request to students who attend the entire event.
+
+Remote participation will make use of the Zurihac infrastructure. We will do our best to stream presentations and to post recordings as quickly as possible, and we will also have a chat system for remote participants.
+
+If you or your company would like to sponsor the event, enabling more students to have financial support to attend, please contact David Thrane Christiansen at [david@haskell.foundation](mailto:david@haskell.foundation).
+
+Registration will open as soon as a few more speakers are confirmed. In the meantime, please register your interest by filling out [this survey](https://www.surveylegend.com/s/4piz), where you can also sign up to be notified when registration opens. Due to the limited space available, participants will be chosen based on their background and interests.
+

--- a/haskell-foundation.cabal
+++ b/haskell-foundation.cabal
@@ -1,14 +1,14 @@
 name:               haskell-foundation
 version:            0.1.0.0
 build-type:         Simple
-cabal-version:      >= 1.10
+cabal-version:      2.0
 
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll
+                  , hakyll ^>=4.15
                   , monadlist
-                  , pandoc
+                  , pandoc >=2.11 && <2.20
                   , text
   ghc-options:      -threaded
   default-language: Haskell2010

--- a/templates/event.html
+++ b/templates/event.html
@@ -1,0 +1,17 @@
+<div class="max-w-screen-xl mx-auto py-16 md:py-24">
+    <div class="text-center pt-12 md:pt-20 px-12 sm:px-16 md:px-24 lg:px-36 ">
+      <h1 class="text-2xl-5xl">$title$</h1>
+    </div>
+
+    <div class="max-w-screen-xl mx-auto">
+        <div class="px-4 sm:px-8 md:px-12 lg:px-16">
+            <div class="mx-auto prose md:prose-lg">
+                <div class="max-w-screen-xl mx-auto grid gap-8 lg:grid-cols-2 md:px-12 bg-gray-100">
+                    <div class="text-lg"><strong>Posted:</strong> </div>
+                    <div class="text-lg"><strong>Status:</strong> </div>
+                </div>
+                $body$
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/events/list.html
+++ b/templates/events/list.html
@@ -1,0 +1,55 @@
+---
+title: Events
+---
+<div class="max-w-screen-xl mx-auto py-16 md:py-24">
+  <div class="sm:px-6 lg:px-16">
+    <div class="relative">
+      <div class="absolute top-0 left-0 border-t border-l border-purple-50 h-10 md:h-20 w-10 md:w-20">
+        <div
+          class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-100 h-10 md:h-20 w-10 md:w-20">
+          <div
+            class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-200 h-10 md:h-20 w-10 md:w-20">
+            <div
+              class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-300 h-10 md:h-20 w-10 md:w-20">
+              <div
+                class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-400 h-10 md:h-20 w-10 md:w-20">
+                <div
+                  class="absolute top-1 md:top-2 left-1 md:left-2 border-t border-l border-purple-500 h-10 md:h-20 w-10 md:w-20">
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="absolute top-0 right-0 border-t border-r border-purple-50 h-10 md:h-20 w-10 md:w-20">
+        <div
+          class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-100 h-10 md:h-20 w-10 md:w-20">
+          <div
+            class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-200 h-10 md:h-20 w-10 md:w-20">
+            <div
+              class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-300 h-10 md:h-20 w-10 md:w-20">
+              <div
+                class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-400 h-10 md:h-20 w-10 md:w-20">
+                <div
+                  class="absolute top-1 md:top-2 right-1 md:right-2 border-t border-r border-purple-500 h-10 md:h-20 w-10 md:w-20">
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="text-center pt-12 md:pt-20 px-12 sm:px-16 md:px-24 lg:px-36 ">
+    <h1 class="text-2xl-5xl">Events</h1>
+  </div>
+  $if(events)$
+  <div class="mt-16 md:mt-24">
+    <div class="max-w-screen-xl mx-auto grid gap-8 lg:grid-cols-2 md:px-12">
+      $for(events)$
+      $partial("templates/events/tile.html")$
+      $endfor$
+    </div>
+  </div>
+  $endif$
+</div>

--- a/templates/events/page.html
+++ b/templates/events/page.html
@@ -1,0 +1,21 @@
+<div class="max-w-screen-xl mx-auto">
+  <div class="xl:max-w-screen-xl mx-auto md:px-12 lg:px-16 py-16 md:py-24">
+    <div class="bg-gray-800 shadow-lg shadow-xl shadow-md shadow-sm px-6 sm:px-12 md:px-12 lg:px-16 py-16 md:py-20">
+      <h2 class="text-gray-50 font-normal text-3xl-4xl text-center">$title$</h2>
+      <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
+        $summary$
+      </p>
+    </div>
+  </div>
+</div>
+<div class="max-w-screen-xl mx-auto">
+  <div class="px-4 sm:px-8 md:px-12 lg:px-16">
+    <div class="mx-auto prose md:prose-lg">
+      <div class="max-w-screen-xl mx-auto grid gap-8 lg:grid-cols-2 md:px-12 bg-gray-100">
+        <div class="text-lg"><strong>Location:</strong> $location$ </div>
+        <div class="text-lg"><strong>Dates:</strong> $daterange$ </div>
+      </div>
+      $body$
+    </div>
+  </div>
+</div>

--- a/templates/events/tile.html
+++ b/templates/events/tile.html
@@ -1,0 +1,16 @@
+<div class="bg-white border border-gray-300 rounded py-8 px-6 sm:px-12 text-center">
+  <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-6 lg:py-24">
+    <div class="space-y-4">
+      <h2 class="text-center text-2xl-4xl font-normal">$title$</h2>
+      <p>$summary$</p>
+      <table>
+        <!-- the p tags here are to work around Tailwind being incomprehensible - DTC 2023-03-01 -->
+        <tr><th scope="row" style="text-align: right;">Dates:</th><td><p>$daterange$</p></td></tr>
+        <tr><th scope="row" style="text-align: right;">Location:</th><td><p>$location$</p></td></tr>
+      </table>
+      <div class="mt-4">
+        <a class="arrow-link" href="$url$">&gt;&gt; Read more</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -44,6 +44,13 @@
             </div>
         </div>
         $endfor$
+
+        $if(events)$
+        $for(events)$
+        $partial("templates/events/tile.html")$
+        $endfor$
+        $endif$
+
     </div>
 </div>
 


### PR DESCRIPTION
Event tiles are now shown on the front page together with the news and with podcast episodes. There's also an event list that can be found by URL hacking.

The motivation for this is the announcement of the 2023 GHC contributors' workshop, included also in this PR.