### PR TITLE
Add February update

### DIFF
--- a/news/2023-03-01/haskell-foundation-february-update.markdown
+++ b/news/2023-03-01/haskell-foundation-february-update.markdown
@@ -1,0 +1,5 @@
+---
+title: Haskell Foundation February 2023 Update
+---
+
+David Thrane Christiansen posted the <a href='https://discourse.haskell.org/t/haskell-foundation-february-2023-update/5896' target='_blank'>February 2023 Foundation update</a> in our community's Discourse instance.

--- a/site.hs
+++ b/site.hs
@@ -249,7 +249,7 @@ main = hakyll $ do
             podcastsCtx <- podcastListCtx . take 1 . reverse . sortOn podcastOrd <$> loadAll ("podcast/*/index.markdown" .&&. hasVersion "raw")
             careers <- loadAll @String "careers/*.markdown"
             careersCtx <- careersCtx . reverse <$> loadAll "careers/*.markdown"
-            announces  <- take 1 <$> (recentFirst =<< loadAll @String "news/*/**.markdown")
+            announces  <- take 1 <$> (recentFirst =<< loadAll @String ("news/*/**.markdown" .&&. hasNoVersion))
             let announceCtx = announcementsCtx announces
             eventsCtx <- activeEventsCtx <$> (recentFirst =<< loadAll ("events/*.markdown" .&&. hasNoVersion))
 


### PR DESCRIPTION
Also fix a bug that caused it to be incorrectly displayed on the front page. The bug was another instance of the `description` version clashing, causing an incorrectly-rendered output (from `pandocPlainCompiler`) to be displayed.

