### PR TITLE
Revert "Hide dashboards until after vacation"

### DIFF
--- a/reports/devops-2023.markdown
+++ b/reports/devops-2023.markdown
@@ -140,7 +140,6 @@ summary: Achievements and reflections from a year of improvements to GHC's CI
 
 <p>If we consider the whole Haskell forest, my work on GHC CI is a small thing: little mushrooms under a great tree. But I’ve done what I can. I have reduced the workload with automation, pitched in to spread the work that remained, and made myself and others more efficient with more tools and data. The highlight of my work is the system I built for automatically repairing spurious failures. I can only hope that it wasn't a complete coincidence that GHC maintainers think 9.6 was the smoothest release in recent history. Besides, mushrooms aren't just funny-looking protuberances in the dirt—they are vast subterranean mesh networks that symbiotically connect other forest life! Small changes have big effects. That's why I'm happy to keep my hands dirty and keep chipping away at the problems, particularly with the new perspective and data I’ve gained through reflecting on this year of work.</p>
 
-<!--
 <h2>Addendum: Live Charts</h2>
 
 <p>Many of the charts in this log are now implemented as dashboards so I (or anybody else) can keep tabs on CI health. Click on them to see them live!</p>
@@ -160,4 +159,3 @@ summary: Achievements and reflections from a year of improvements to GHC's CI
 <img alt="Screenshot of CI Spurious Failures dashboard" src="spurious-failures-dashboard.png">
 </a>
 
--->


### PR DESCRIPTION
This reverts commit 1ad4c4eb53836f3ad2952a28420f85765423e9cb.

Ben figured out what went wrong with the Grafana config and fixed it.