### PR TITLE
Hide board committees for current board

### DIFF
--- a/templates/who-we-are/exec-and-board.html
+++ b/templates/who-we-are/exec-and-board.html
@@ -69,7 +69,7 @@
       <p>
         $body$
       </p>
-      $if(committees)$
+      $if(false)$
       <div>
         <div class="font-bold text-gray-600">Committees</div>
         <p>$committees$</p>


### PR DESCRIPTION
Board committees aren't the way we mainly organize now, so this takes them off the web page.