### PR TITLE
Say "sponsorship" not "membership"

### DIFF
--- a/templates/donations/list.html
+++ b/templates/donations/list.html
@@ -101,7 +101,7 @@ title: Donations and Sponsorship
               <div class="text-gray-600 text-xl font-medium">USD $$70k+ / year</div>
             </div>
             <p class="">
-              All of the benefits of Functor and Applicative memberships, with the addition of a full interview for the Haskell Foundation blog, as well as having your logo prominently displayed on the HF website.
+              All of the benefits of Functor and Applicative sponsorships, with the addition of a full interview for the Haskell Foundation blog, as well as having your logo prominently displayed on the HF website.
             </p>
           </div>
 


### PR DESCRIPTION
A sponsor recently asked about "membership", but that's not a term we're using any more. I'm pretty sure they got it from our donations page, which this PR updates.