### PR TITLE
static -> assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://haskellfoundation.github.io/assets/images/logos/hf-logo-alpha.png" width="350" height="282" alt="Haskell Foundation" title="Haskell Foundation">
+<img src="https://haskell.foundation/assets/images/logos/hf-logo-alpha.png" width="350" height="282" alt="Haskell Foundation" title="Haskell Foundation">
 </p>
 
 # The Haskell Foundation Website

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://haskellfoundation.github.io/static/images/logos/hf-logo-alpha.png" width="350" height="282" alt="Haskell Foundation" title="Haskell Foundation">
+<img src="https://haskellfoundation.github.io/assets/images/logos/hf-logo-alpha.png" width="350" height="282" alt="Haskell Foundation" title="Haskell Foundation">
 </p>
 
 # The Haskell Foundation Website


### PR DESCRIPTION
The top image in the readme is broken as it points to the old `static` path.