### PR TITLE
Remove link to SPJ Announcement video: fixes #375

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -53,7 +53,7 @@
     </div>
   </div>
 
-
+<!--
   <div class="relative bg-white mt-24 lg:w-2/3">
     <div class="absolute -z-10 left-0 top-0 right-6 bottom-6 border-3 border-purple-700"></div>
     <div class="absolute -z-10 left-6 top-6 right-0 bottom-0 border-3 border-purple-700"></div>
@@ -77,6 +77,7 @@
     </div>
   </div>
 </div>
+  -->
 
 <div class="bg-gray-800 mt-24">
   <div class="max-w-screen-xl mx-auto px-6 sm:px-12 lg:px-16 py-16 md:py-24 py-20 md:py-28 xl:py-32">


### PR DESCRIPTION
The video is currently unavailable.

Ideally we will be able to find/upload a new link to the video and then we'll change this back.

As such, this temporarily fixes #375 