### PR TITLE
ci: Use --allow-empty

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,6 @@ jobs:
             cp -a -v _site/. .
             #  Commit
             git add --all
-            git commit -m "[`date '+%F %T %Z'`] New release [ci skip]"
+            git --allow-empty commit -m "[`date '+%F %T %Z'`] New release [ci skip]"
             # Push
             git push origin main:main


### PR DESCRIPTION
this way the deploy will not fail if it happened to not change any
output