### PR TITLE
Update roles of board members.

### DIFF
--- a/who-we-are/people/andresloeh.markdown
+++ b/who-we-are/people/andresloeh.markdown
@@ -1,6 +1,6 @@
 ---
 name: Andres Löh
-title: Secretary
+title: Chair
 executiveTeam: "False"
 tenureStart: 2023-04-01
 image: "/assets/images/board-members/andres.png"

--- a/who-we-are/people/davidchristiansen.markdown
+++ b/who-we-are/people/davidchristiansen.markdown
@@ -1,9 +1,10 @@
 ---
 name: David Thrane Christiansen
 email: david@haskell.foundation
-title: Former Executive Director
-executiveTeam: "False"
+title: Executive Director
+executiveTeam: "True"
 tenureStart: 2022-05-02
+tenureEnd: 2023-09-30
 image: /assets/images/exec-team/dtc.png
 website: https://davidchristiansen.dk
 ---

--- a/who-we-are/people/mikepilgrem.markdown
+++ b/who-we-are/people/mikepilgrem.markdown
@@ -1,6 +1,6 @@
 ---
 name: Mike Pilgrem
-title: Board Member
+title: Secretary
 executiveTeam: "False"
 tenureStart: 2024-04-25
 image: /assets/images/board-members/mpilgrem.png


### PR DESCRIPTION
Mike is now Secretary.
Andres is now Chair.
David should be listed in the "Past Executive Team Members" section.