### PR TITLE
Restore link to SPJ Announcement video

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -53,7 +53,6 @@
     </div>
   </div>
 
-<!--
   <div class="relative bg-white mt-24 lg:w-2/3">
     <div class="absolute -z-10 left-0 top-0 right-6 bottom-6 border-3 border-purple-700"></div>
     <div class="absolute -z-10 left-6 top-6 right-0 bottom-0 border-3 border-purple-700"></div>
@@ -61,7 +60,7 @@
       <div class="bg-white relative border-3 border-purple-700 px-6 sm:px-12 lg:px-16 pb-12">
         <div class="lg:absolute lg:left-full lg:w-2/3 lg:-ml-36 lg:top-1/2 lg:transform lg:-translate-y-1/2">
           <div class="youtube-video -mt-12 lg:mt-0">
-            <iframe class="absolute w-full h-full left-0 top-0 rounded shadow-md" src="https://www.youtube.com/embed/g_vCBsEiSTY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe class="absolute w-full h-full left-0 top-0 rounded shadow-md" src="https://www.youtube.com/embed/il-MdME8bHo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
           </div>
         </div>
         <div class="mt-8 space-y-6 lg:pr-32">
@@ -77,7 +76,6 @@
     </div>
   </div>
 </div>
-  -->
 
 <div class="bg-gray-800 mt-24">
   <div class="max-w-screen-xl mx-auto px-6 sm:px-12 lg:px-16 py-16 md:py-24 py-20 md:py-28 xl:py-32">


### PR DESCRIPTION
The link was commented out in beadf8fd1, see #375. The video is now available again. (On the other hand, I am not sure if the video is still relevant after nearly 4 years.)

This PR also fixes an HTML bug: beadf8fd1 commented out one closing `</div>` too much.

