### PR TITLE
Fix some HTML errors

### DIFF
--- a/templates/boilerplate.html
+++ b/templates/boilerplate.html
@@ -40,10 +40,8 @@
   <!-- metadata -->
   <title>$title$</title>
   <meta property="og:title" content="$title$">
-  </meta>
   $if(description)$
   <meta property="og:description" content="$description$">
-  </meta>
   $endif$
 
 </head>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -53,7 +53,7 @@
 
     <div class="flex flex-row">
       <div class="mt-16 flex flex-col text-center flex-grow lg:flex-row lg:space-x-8 lg:space-y-0">
-        <img src="/assets/images/logos/hf-logo-100-alpha.png" class="h-8" />
+        <img src="/assets/images/logos/hf-logo-100-alpha.png" class="h-8" alt="Logo of the Haskell Foundation"/>
         <div class="font-medium">2024 © Haskell Foundation, <a href="https://github.com/haskellfoundation/haskellfoundation.github.io">submit website bug reports and fixes on GitHub</a></div>
       </div>
 

--- a/templates/mobile-nav-flyout.html
+++ b/templates/mobile-nav-flyout.html
@@ -5,7 +5,7 @@
   <div class="pt-6 flex justify-between">
 
     <div>
-      <img src="/assets/images/logos/hf-logo-100-alpha.png" width="68" height="52" />
+      <img src="/assets/images/logos/hf-logo-100-alpha.png" width="68" height="52" alt="Logo of the Haskell Foundation"/>
       <div class="text-sm mt-2 text-gray-500">The Haskell Foundation</div>
     </div>
 

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -2,7 +2,7 @@
 
   <div>
     <a href="/">
-      <img src="/assets/images/logos/hf-logo-100-alpha.png" />
+      <img src="/assets/images/logos/hf-logo-100-alpha.png" alt="The Haskell Foundation homepage"/>
       <div class="text-sm mt-2 text-gray-500"></div>
     </a>
   </div>

--- a/templates/news/frontpage.html
+++ b/templates/news/frontpage.html
@@ -2,7 +2,7 @@
   <div class="bg-gray-100 px-6 sm:px-12 lg:px-16 py-6 lg:py-24 h-full">
     <div class="space-y-4">
       <h2 class="text-center text-2xl-4xl font-normal">$title$</h2>
-      <p>$body$</p>
+      $body$
 
       $if(link)$
       <div class="mt-4">


### PR DESCRIPTION
...as reported by the [w3c validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Fhaskell.foundation%2F).

Another error is fixed in #429.

The `border` issues reported by the validator look like a magic workaround for some browser bug. I was afraid to touch this.

Solving the `srcset` without `source` problem needs some time to choose the right numbers, which I don't have at the moment.