### PR TITLE
Allow github actions to commit to the branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,17 +37,18 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         name: Setup Haskell Stack
         with:
           ghc-version: ${{ matrix.ghc }}
           stack-version: ${{ matrix.stack }}
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
+        id: cache
         name: Cache ~/.stack
         with:
           path: ~/.stack
@@ -57,7 +58,10 @@ jobs:
       - name: Build dependencies
         run: stack build --system-ghc --only-dependencies
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
+        # We shouldn't ever run into an exact key hit (in theory),
+        # but this prevents errors if we do.
+        if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: ~/.stack
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ on:
   schedule:
     - cron: '0 7 * * 1'  # 8AM CET/11PM PT on Mondays
 
+# Allow github actions to commit to the branch
+permissions:
+  contents: write
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Github uses the GITHUB_TOKEN for setting permissions for all of the workflows.
The default setting for this, according to the documentation, is "read and write" to most everything.

Recently, github created the ability for one to set the default organization wide.
They also flipped the default (which is what we ran into).
This wasn't super well documented and even I missed it, but here's the announcement where they changed the defaults for all new organizations and enterprises: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/

I'm not quite sure why we only started to run into this a few days ago, but the default got changed from read/write to read for us.
Whicyh, honestly, is a good default, I approve of that; it just breaks this one workflow, so here's the fix for that.
