### PR TITLE
Podcast 56: Update Bluespec name and link

### DIFF
--- a/podcast/56/links.markdown
+++ b/podcast/56/links.markdown
@@ -5,7 +5,7 @@
 * [Kubernetes](https://kubernetes.io/)
 * [FP castle](https://fpcastle.com/)
 * [Miranda](https://www.cs.kent.ac.uk/people/staff/dat/miranda/)
-* [BlueSpec](https://bluespec.com/)
+* [Bluespec](https://github.com/B-Lang-org/bsc)
 * [Dagstuhl](https://www.dagstuhl.de/en/seminars/dagstuhl-seminars)
 * [Arran (scottish island)](https://www.visitarran.com/)
 * [BBC Micro](https://en.wikipedia.org/wiki/BBC_Micro)


### PR DESCRIPTION
Bluespec is an overloaded term: it can refer to the company (Bluespec Inc) but it can also refer to a set of hardware design languages and the compiler and other tools for them.  In the podcast, Satnam's mentions of Bluespec was referring to the language, but the link here is for the company.  The Bluespec language and tools have been made open-source and are managed by a separate organization (B-Lang Org).  This PR changes the link to point to B-Lang Org's GitHub repo for BSC, the Bluespec compiler.  It also corrects the capitalization of Bluespec.  Thanks!