### PR TITLE
Added link to GitHub in footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -46,6 +46,7 @@
         <a href="https://discourse.haskell.org/c/haskell-foundation/11" target="_blank" class="text-4xl block"><span class="fab fa-discourse"></span></a>
         <a rel="me" href="https://mastodon.social/@haskell_foundation" target="_blank" class="text-4xl block"><span class="fab fa-mastodon"></span></a>
         <a href="https://www.youtube.com/@HaskellFoundation" target="_blank" class="text-4xl block"><span class="fab fa-youtube"></span></a>
+        <a href="https://github.com/haskellfoundation" target="_blank" class="text-4xl block"><span class="fab fa-github"></span></a>
       </div>
     </div>
 


### PR DESCRIPTION
I was looking for the Haskell Foundation GitHub account and mistakenly found [this one](https://github.com/haskell-foundation) instead of the real one. I couldn't find a direct link on haskell.foundation

This PR adds a GitHub icon in the footer such that it now looks like this (last icon on the right):

![image](https://github.com/user-attachments/assets/20abdb72-93dc-4ecf-add9-701976296898)

