### PR TITLE
Don't require affiliates to subscribe to GFRC

### DIFF
--- a/affiliates/about/index.html
+++ b/affiliates/about/index.html
@@ -132,23 +132,8 @@ title: About the Haskell Foundation
 
         <h3>CODE OF CONDUCT</h3>
         <p>
-          Groups must adopt the <a href="/guidelines-for-respectful-communication">Guidelines for Respectful Communication</a>. Groups may additionally adopt other guidelines & CoCs that are stronger; as long as they do not conflict with the GRC.
+          Groups are encouraged to adopt the <a href="/guidelines-for-respectful-communication">Guidelines for Respectful Communication</a>. Groups may also adopt other guidelines & CoCs; as long as they do not conflict with the GRC.
         </p>
-        <p>
-          Why make a code of conduct as part of HF affiliation?
-        </p>
-        <ul>
-          <li>
-            <p>
-              We want the Haskell community to be welcoming, diverse, and inclusive. Having explicit guidelines for respectful communication signals that desire, and makes it more explicit and concrete.
-            </p>
-          </li>
-          <li>
-            <p>
-              For all of us, as individuals and as groups, making an explicit commitment to respectful communication encourages us to review our messages to see if they meet the goals set out in the guidelines, and will give others some specifics to point to if we fail.
-            </p>
-          </li>
-        </ul>
 
         <h2>Affiliated Projects</h2>
 
@@ -175,7 +160,7 @@ title: About the Haskell Foundation
           </li>
           <li>
             <p>
-              Just like committees, the project must adopt the <a href="/guidelines-for-respectful-communication">Guidelines for Respectful Communication</a> as a code of conduct.
+              The project is encouraged to adopt the <a href="/guidelines-for-respectful-communication">Guidelines for Respectful Communication</a> as a code of conduct.
             </p>
           </li>
         </ul>

--- a/templates/affiliates/list.html
+++ b/templates/affiliates/list.html
@@ -10,8 +10,8 @@ title: Affiliates
         that the Haskell Foundation in turn supports this group.
       </div>
       <div>
-        We require affiliated groups to adhere to guidelines around transparency, being open to new members, and follow
-        the <a href="/guidelines-for-respectful-communication" target="_blank">Haskell committee guidelines for
+        We require affiliated groups to adhere to guidelines around transparency, being open to new members, and encourage them to follow
+        the <a href="/guidelines-for-respectful-communication" target="_blank">Guidelines for
           respectful communication</a>. We believe that this will help us grow towards being a more open and welcoming
         community.
       </div>


### PR DESCRIPTION
Both the GHCup project and the CLC were apparently not informed that they are obliged to subscribe to the GFRC. The GFRC has several problems, which also made the CLC [reluctant](https://github.com/haskell/core-libraries-committee/issues/320) to adopt it explicitly. I'm trying to address those concerns here: https://github.com/haskellfoundation/haskellfoundation.github.io/pull/480

Even in case the above is fixed, requiring affiliates to subscribe to it is against the GFRC text itself, isn't it?

> We do not seek to impose these guidelines on members of the Haskell community generally.

I think it's better that we collaborate on the text and then make clear it is opt-in.

If an affiliate acts wildly in dissonance with the GFRC, then I think it's in the HFs best interest to remove them from their affiliation program. I just think it's odd to try to "backdoor" a CoC into other projects.