### PR TITLE
Fix links to QBayLogic logos

### DIFF
--- a/donations/sponsors/qbaylogic.markdown
+++ b/donations/sponsors/qbaylogic.markdown
@@ -1,7 +1,7 @@
 ---
 title: QBayLogic
-logo: /assets/images/sponsors/qbaylogic/qbaylogic-logo-683.png
-srcset: /assets/images/sponsors/qbaylogic/qbaylogic-200.png 200w, /assets/images/sponsors/qbaylogic/qbaylogic-400.png 400w, /assets/images/sponsors/qbaylogic/qbaylogic-logo-683.png 683w
+logo: /assets/images/sponsors/qbaylogic/qbaylogic-683.png
+srcset: /assets/images/sponsors/qbaylogic/qbaylogic-200.png 200w, /assets/images/sponsors/qbaylogic/qbaylogic-400.png 400w, /assets/images/sponsors/qbaylogic/qbaylogic-683.png 683w
 externalUrl: https://www.digitalocean.com
 level: Functor
 ---


### PR DESCRIPTION
Fix broken links to QBayLogic logo.

Followup on https://github.com/haskellfoundation/haskellfoundation.github.io/pull/496 (CC @jmct)
I noticed that logos don't display properly on the HF website.

It was because these links were not aligned with actual file names

![Screenshot from 2025-04-24 06-30-06](https://github.com/user-attachments/assets/62f3d732-cae3-4643-a818-169da9c8e7a4)

