### PR TITLE
Fix 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,3 +1,6 @@
+---
+title: Page not found
+---
 <div class="max-w-screen-xl mx-auto py-16 md:py-24">
   $partial("templates/corners.html")$
   <div class="text-center pt-12 md:pt-20 px-12 sm:px-16 md:px-24 lg:px-36 ">

--- a/site.hs
+++ b/site.hs
@@ -335,7 +335,6 @@ main = hakyll $ do
             getResourceBody
                 >>= applyAsTemplate sponsors
                 >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
-                >>= relativizeUrls
 
 -- careers ---------------------------------------------------------------------------------------------
     create ["careers/index.html"] $ do


### PR DESCRIPTION
Currently, `404.html` is used everywhere, however, since link are relativized, it breaks on non-root URLS:

https://haskell.foundation/podcast/999

![image](https://github.com/user-attachments/assets/50c8eee7-546a-43da-ade7-b0dd4e39edfa)

I have dropped the relativization and added a title.