### PR TITLE
Loosen dependency bounds to build using recent Hackage package lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,21 @@ To build the project:
 
 ```bash
 stack build
+# alternatively: cabal build
 ```
 
 Once the project has built (which can take a while due to the dependencies for Hakyll), generate the site with:
 
 ```bash
 stack exec -- site build
+# alternatively: cabal run -- site build
 ```
 
 and for development use:
 
 ```bash
 stack run -- site watch
+# alternatively: cabal run -- site watch
 ```
 
 The site will be build in the `_site` directory, and you can open the files in your browser of choice. Due to a Hakyll issue, some sponsor logos will not show up correctly. This is expected behavior, and should be fine for the deployed site.

--- a/haskell-foundation.cabal
+++ b/haskell-foundation.cabal
@@ -6,9 +6,9 @@ cabal-version:      2.0
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll ^>= 4.14 || ^>= 4.15
+                  , hakyll ^>= 4.14 || ^>= 4.15 || ^>= 4.16
                   , monadlist
-                  , pandoc >=2.11 && <2.20
+                  , pandoc >=2.11 && <3.8
                   , filepath ^>= 1.4
                   , text
   ghc-options:      -threaded


### PR DESCRIPTION
This pull request updates some of the dependency bounds, allowing to build with recent versionso f Hakyll (4.16+) and pandoc (3+).

Note that this is mostly for local development, as the CI pipeline still uses stack