### PR TITLE
Remove social area width from footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -40,7 +40,7 @@
         </div>
       </div>
 
-      <div class="flex space-x-4 w-44">
+      <div class="flex space-x-4">
         <a href="https://twitter.com/haskellfound" target="_blank" class="text-4xl block"><span class="fab fa-twitter"></span></a>
         <a href="https://www.linkedin.com/company/haskell-foundation-inc" target="_blank" class="text-4xl block"><span class="fab fa-linkedin-in"></span></a>
         <a href="https://discourse.haskell.org/c/haskell-foundation/11" target="_blank" class="text-4xl block"><span class="fab fa-discourse"></span></a>


### PR DESCRIPTION
Before: 
<img width="2369" height="718" alt="social icons spilling out over the right edge of the page" src="https://github.com/user-attachments/assets/72446e64-f928-4699-b68b-e9bd188e96ac" />

After:
<img width="2369" height="718" alt="social icons now nicely contained within the footer, consuming more space from the left" src="https://github.com/user-attachments/assets/f7ffb408-4bc2-400d-931e-b5e08dd8174e" />