### PR TITLE
Updated sponsors as of June 2026

### DIFF
--- a/donations/sponsors/channable.markdown
+++ b/donations/sponsors/channable.markdown
@@ -3,5 +3,5 @@ title: Channable
 logo: /assets/images/sponsors/channable/channable-683.png
 srcset: /assets/images/sponsors/channable/channable-200.png 200w, /assets/images/sponsors/channable/channable-400.png 400w, /assets/images/sponsors/channable/channable-683.png 683w
 externalUrl: https://www.channable.com/
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/digital-ocean.markdown
+++ b/donations/sponsors/digital-ocean.markdown
@@ -3,5 +3,5 @@ title: DigitalOcean
 logo: /assets/images/sponsors/digital-ocean/DO-logo-683.png
 srcset: /assets/images/sponsors/digital-ocean/DO-logo-200.png 200w, /assets/images/sponsors/digital-ocean/DO-logo-400.png 400w, /assets/images/sponsors/digital-ocean/DO-logo-683.png 683w
 externalUrl: https://www.digitalocean.com
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/google.markdown
+++ b/donations/sponsors/google.markdown
@@ -3,5 +3,5 @@ title: Google
 logo: /assets/images/sponsors/google/google-683.png
 srcset: /assets/images/sponsors/google/google-200.png 200w, /assets/images/sponsors/google/google-400.png 400w, /assets/images/sponsors/google/google-683.png 683w
 externalUrl: https://opensource.google/
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/iohk.markdown
+++ b/donations/sponsors/iohk.markdown
@@ -3,6 +3,6 @@ title: IOHK
 logo: /assets/images/sponsors/iohk/iohk-683.png
 srcset: /assets/images/sponsors/iohk/iohk-200.png 200w, /assets/images/sponsors/iohk/iohk-400.png 400w, /assets/images/sponsors/iohk/iohk-683.png 683w
 externalUrl: https://iohk.io/
-level: Monad
+level: Gold
 careersUrl: https://apply.workable.com/io-global
 ---

--- a/donations/sponsors/juspay.markdown
+++ b/donations/sponsors/juspay.markdown
@@ -2,6 +2,6 @@
 title: Juspay
 logo: /assets/images/sponsors/juspay/juspay_logo.png
 externalUrl: https://juspay.in
-level: Monad
+level: Gold
 careersUrl: https://juspay.in/careers
 ---

--- a/donations/sponsors/mercury.markdown
+++ b/donations/sponsors/mercury.markdown
@@ -2,6 +2,6 @@
 title: Mercury
 logo: /assets/images/sponsors/mercury/mercury.png
 externalUrl: https://mercury.com/
-level: Monad
+level: Gold
 careersUrl: https://mercury.com/jobs
 ---

--- a/donations/sponsors/obsidian.markdown
+++ b/donations/sponsors/obsidian.markdown
@@ -3,6 +3,6 @@ title: Obsidian Systems
 logo: /assets/images/sponsors/obsidian-systems/obsidian-systems-683.png
 srcset: /assets/images/sponsors/obsidian-systems/obsidian-systems-200.png 200w, /assets/images/sponsors/obsidian-systems/obsidian-systems-400.png 400w, /assets/images/sponsors/obsidian-systems/obsidian-systems-683.png 683w
 externalUrl: https://obsidian.systems/
-level: Applicative
+level: Silver
 careersUrl: https://www.reddit.com/r/haskell/comments/m2tqca/jobs_obsidian_systems_is_hiring/
 ---

--- a/donations/sponsors/previous/artificial.markdown
+++ b/donations/sponsors/previous/artificial.markdown
@@ -3,5 +3,5 @@ title: Artificial
 logo: /assets/images/sponsors/artificial/artificial-683.png
 srcset: /assets/images/sponsors/artificial/artificial-200.png 200w, /assets/images/sponsors/artificial/artificial-400.png 400w, /assets/images/sponsors/artificial/artificial-683.png 683w
 externalUrl: https://artificial.io/
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/previous/carboncloud.markdown
+++ b/donations/sponsors/previous/carboncloud.markdown
@@ -2,6 +2,6 @@
 title: CarbonCloud
 logo: /assets/images/sponsors/carboncloud/vertical3x.png
 externalUrl: https://www.carboncloud.com/
-level: Applicative
+level: Silver
 careersUrl: https://careers.carboncloud.com/jobs
 ---

--- a/donations/sponsors/previous/digitalasset.markdown
+++ b/donations/sponsors/previous/digitalasset.markdown
@@ -2,5 +2,5 @@
 title: Digital Asset
 logo: /assets/images/sponsors/digital-asset/digital-asset-logo-light.png
 externalUrl: https://digitalasset.com/
-level: Applicative
+level: Silver
 ---

--- a/donations/sponsors/previous/exfreight.markdown
+++ b/donations/sponsors/previous/exfreight.markdown
@@ -2,5 +2,5 @@
 title: ExFreight
 logo: /assets/images/sponsors/exfreight/exfreight.png
 externalUrl: https://www.exfreight.com/
-level: Applicative
+level: Silver
 ---

--- a/donations/sponsors/previous/flipstone.markdown
+++ b/donations/sponsors/previous/flipstone.markdown
@@ -3,5 +3,5 @@ title: FlipStone
 logo: /assets/images/sponsors/flipstone/flipstone-683.png
 srcset: /assets/images/sponsors/flipstone/flipstone-200.png 200w, /assets/images/sponsors/flipstone/flipstone-400.png 400w, /assets/images/sponsors/flipstone/flipstone-683.png 683w
 externalUrl: https://flipstone.com/
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/previous/freckle.markdown
+++ b/donations/sponsors/previous/freckle.markdown
@@ -3,6 +3,6 @@ title: Freckle
 logo: /assets/images/sponsors/freckle/freckle-logo-683.png
 srcset: /assets/images/sponsors/freckle/freckle-logo-200.png 200w, /assets/images/sponsors/freckle/freckle-logo-400.png 400w, /assets/images/sponsors/freckle/freckle-logo-683.png 683w
 externalUrl: https://freckle.com/
-level: Functor
+level: Bronze
 careersUrl: https://jobs.smartrecruiters.com/Renaissance/743999815260637-staff-software-engineer-full-stack-
 ---

--- a/donations/sponsors/previous/github.markdown
+++ b/donations/sponsors/previous/github.markdown
@@ -3,5 +3,5 @@ title: GitHub
 logo: /assets/images/sponsors/github/github-683.png
 srcset: /assets/images/sponsors/github/github-200.png 200w, /assets/images/sponsors/github/github-400.png 400w, /assets/images/sponsors/github/github-683.png 683w
 externalUrl: https://github.com/
-level: Monad
+level: Gold
 ---

--- a/donations/sponsors/previous/herp.markdown
+++ b/donations/sponsors/previous/herp.markdown
@@ -2,5 +2,5 @@
 title: HERP
 logo: /assets/images/sponsors/herp/black.png
 externalUrl: https://herp.co.jp/
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/previous/meta.markdown
+++ b/donations/sponsors/previous/meta.markdown
@@ -2,5 +2,5 @@
 title: Meta
 logo: /assets/images/sponsors/meta/Meta_lockup_positive.png
 externalUrl: https://meta.com/
-level: Monad
+level: Gold
 ---

--- a/donations/sponsors/previous/mlabs.markdown
+++ b/donations/sponsors/previous/mlabs.markdown
@@ -3,5 +3,5 @@ title: MLabs
 externalUrl: https://mlabs.city/
 careersUrl: https://apply.workable.com/mlabs/
 logo: /assets/images/sponsors/mlabs/logo-black-pink.png
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/previous/platonicsystems.markdown
+++ b/donations/sponsors/previous/platonicsystems.markdown
@@ -3,6 +3,6 @@ title: Platonic Systems
 logo: /assets/images/sponsors/platonic-systems/platonic-systems-683.png
 srcset: /assets/images/sponsors/platonic-systems/platonic-systems-200.png 200w, /assets/images/sponsors/platonic-systems/platonic-systems-400.png 400w, /assets/images/sponsors/platonic-systems/platonic-systems-683.png 683w
 externalUrl: https://platonic.systems
-level: Applicative
+level: Silver
 ---
 

--- a/donations/sponsors/qbaylogic.markdown
+++ b/donations/sponsors/qbaylogic.markdown
@@ -3,5 +3,5 @@ title: QBayLogic
 logo: /assets/images/sponsors/qbaylogic/qbaylogic-683.png
 srcset: /assets/images/sponsors/qbaylogic/qbaylogic-200.png 200w, /assets/images/sponsors/qbaylogic/qbaylogic-400.png 400w, /assets/images/sponsors/qbaylogic/qbaylogic-683.png 683w
 externalUrl: https://qbaylogic.com/
-level: Functor
+level: Bronze
 ---

--- a/donations/sponsors/standard-chartered.markdown
+++ b/donations/sponsors/standard-chartered.markdown
@@ -2,6 +2,6 @@
 title: Standard Chartered
 logo: /assets/images/sponsors/standard-chartered/scb-logo.png
 externalUrl: https://www.sc.com/en/
-level: Monad
+level: Gold
 careersUrl: https://www.sc.com/en/global-careers/
 ---

--- a/donations/sponsors/tripshot.markdown
+++ b/donations/sponsors/tripshot.markdown
@@ -2,6 +2,6 @@
 title: TripShot
 logo: /assets/images/sponsors/tripshot/Tripshot_Logo_RGB.png
 externalUrl: https://tripshot.com/
-level: Functor
+level: Bronze
 careersUrl: https://tripshot.com/careers
 ---

--- a/donations/sponsors/tweag.markdown
+++ b/donations/sponsors/tweag.markdown
@@ -3,6 +3,6 @@ title: Tweag
 logo: /assets/images/sponsors/tweag/tweag-683.png
 srcset: /assets/images/sponsors/tweag/tweag-200.png 200w, /assets/images/sponsors/tweag/tweag-400.png 400w, /assets/images/sponsors/tweag/tweag-683.png 683w
 externalUrl: https://tweag.io/
-level: Applicative
+level: Silver
 careersUrl: https://boards.greenhouse.io/tweag
 ---

--- a/donations/sponsors/welltyped.markdown
+++ b/donations/sponsors/welltyped.markdown
@@ -3,5 +3,5 @@ title: Well-Typed
 logo: /assets/images/sponsors/well-typed/well-typed-683.png
 srcset: /assets/images/sponsors/well-typed/well-typed-200.png 200w, /assets/images/sponsors/well-typed/well-typed-400.png 400w, /assets/images/sponsors/well-typed/well-typed-683.png 683w
 externalUrl: https://well-typed.com/
-level: Applicative
+level: Silver
 ---

--- a/site.hs
+++ b/site.hs
@@ -1,25 +1,29 @@
-{-# Language ScopedTypeVariables #-}
-{-# Language OverloadedStrings #-}
-{-# Language ViewPatterns #-}
-{-# Language TypeApplications #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
-import Hakyll
-import Data.List (sortOn)
 import Control.Monad (filterM, guard)
 import Control.Monad.ListM (sortByM)
-import Hakyll.Web.Template (loadAndApplyTemplate)
-import System.IO (SeekMode(RelativeSeek))
-import Hakyll.Web.Html.RelativizeUrls (relativizeUrls)
-import Hakyll.Web.Template.Context (defaultContext)
-import Data.Maybe (isJust, fromJust, fromMaybe)
-import Text.Pandoc as Pandoc
-    ( Pandoc(..),
-      WriterOptions,
-      Block(Para, Plain),
-      runPure,
-      writePlain, ReaderOptions (readerExtensions), disableExtension, Extension (Ext_tex_math_dollars) )
-import System.FilePath ((</>), dropExtension, splitFileName, takeBaseName)
+import Data.List (sortOn)
+import Data.Maybe (fromJust, fromMaybe, isJust)
 import qualified Data.Text as T
+import Hakyll
+import Hakyll.Web.Html.RelativizeUrls (relativizeUrls)
+import Hakyll.Web.Template (loadAndApplyTemplate)
+import Hakyll.Web.Template.Context (defaultContext)
+import System.FilePath (dropExtension, splitFileName, takeBaseName, (</>))
+import System.IO (SeekMode (RelativeSeek))
+import Text.Pandoc as Pandoc (
+    Block (Para, Plain),
+    Extension (Ext_tex_math_dollars),
+    Pandoc (..),
+    ReaderOptions (readerExtensions),
+    WriterOptions,
+    disableExtension,
+    runPure,
+    writePlain,
+ )
 
 import Debug.Trace (trace)
 
@@ -28,9 +32,9 @@ import Debug.Trace (trace)
 --------------------------------------------------------------------------------------------------------
 main :: IO ()
 main = hakyll $ do
--- statics ---------------------------------------------------------------------------------------------
+    -- statics ---------------------------------------------------------------------------------------------
     match "assets/css/main.css" $ do
-        route   idRoute
+        route idRoute
         compile compressCssCompiler
 
     match "assets/**" $ do
@@ -41,10 +45,10 @@ main = hakyll $ do
         route idRoute
         compile copyFileCompiler
 
--- sponsors --------------------------------------------------------------------------------------------
+    -- sponsors --------------------------------------------------------------------------------------------
     match "donations/sponsors/*.markdown" $ compile pandocCompiler
 
--- in-kind donations -----------------------------------------------------------------------------------
+    -- in-kind donations -----------------------------------------------------------------------------------
     create ["donations/index.html"] $ do
         route idRoute
         compile $ do
@@ -52,12 +56,12 @@ main = hakyll $ do
             iks <- loadAll ("donations/inkind/*.markdown" .&&. hasNoVersion)
 
             let ctx =
-                    listField "inkinds" defaultContext (return iks) <>
-                    defaultContext
+                    listField "inkinds" defaultContext (return iks)
+                        <> defaultContext
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/donations/list.html"  ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"     sponsors
+                >>= loadAndApplyTemplate "templates/donations/list.html" ctx
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
     match "donations/inkind/*.markdown" $ do
@@ -67,11 +71,11 @@ main = hakyll $ do
 
             pandocCompiler
                 >>= applyAsTemplate sponsors
-                >>= loadAndApplyTemplate "templates/donations/page.html"  defaultContext
-                >>= loadAndApplyTemplate "templates/boilerplate.html"     sponsors
+                >>= loadAndApplyTemplate "templates/donations/page.html" defaultContext
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- affiliates ------------------------------------------------------------------------------------------
+    -- affiliates ------------------------------------------------------------------------------------------
     match "affiliates/*.markdown" $ compile pandocCompiler
     create ["affiliates/index.html"] $ do
         route idRoute
@@ -80,11 +84,11 @@ main = hakyll $ do
             ctx <- affiliatesCtx . sortOn itemIdentifier <$> loadAll ("affiliates/*.markdown" .&&. hasNoVersion)
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/affiliates/list.html"   ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"       sponsors
+                >>= loadAndApplyTemplate "templates/affiliates/list.html" ctx
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- projects --------------------------------------------------------------------------------------------
+    -- projects --------------------------------------------------------------------------------------------
     match "projects/*.markdown" $ compile pandocCompiler
     create ["projects/index.html"] $ do
         route idRoute
@@ -94,19 +98,19 @@ main = hakyll $ do
 
             makeItem ""
                 >>= loadAndApplyTemplate "templates/projects/list.html" ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"   sponsors
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- news ------------------------------------------------------------------------------------------------
+    -- news ------------------------------------------------------------------------------------------------
     match "news/**.markdown" $ compile pandocCompiler
     categories <- buildCategories "news/**.markdown" (fromCapture "news/categories/**.html")
 
-    tagsRules categories $ \category catId ->  compile $ do
+    tagsRules categories $ \category catId -> compile $ do
         news <- recentFirst =<< loadAll catId
         let ctx =
-                listField "news" (newsWithCategoriesCtx categories) (pure news) <>
-                dateField "category" "%B %e, %Y"                                <>
-                defaultContext
+                listField "news" (newsWithCategoriesCtx categories) (pure news)
+                    <> dateField "category" "%B %e, %Y"
+                    <> defaultContext
 
         makeItem ""
             >>= loadAndApplyTemplate "templates/news/tile.html" ctx
@@ -119,27 +123,28 @@ main = hakyll $ do
             newsWithCategories <- recentFirst =<< loadAll "news/categories/**.html"
 
             let ctx =
-                    listField "categories" defaultContext (return newsWithCategories) <>
-                    defaultContext
+                    listField "categories" defaultContext (return newsWithCategories)
+                        <> defaultContext
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/news/list.html"     ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"   sponsors
+                >>= loadAndApplyTemplate "templates/news/list.html" ctx
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
     match "news/*.markdown" $ do
-      route $ setExtension "html"
-      let ctxt = mconcat
-            [ defaultContext ]
-      compile $ do
-        sponsors <- buildBoilerplateCtx Nothing
-        pandocCompiler
-          >>= applyAsTemplate sponsors
-          >>= loadAndApplyTemplate "templates/news/page.html" ctxt
-          >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
-          >>= relativizeUrls
+        route $ setExtension "html"
+        let ctxt =
+                mconcat
+                    [defaultContext]
+        compile $ do
+            sponsors <- buildBoilerplateCtx Nothing
+            pandocCompiler
+                >>= applyAsTemplate sponsors
+                >>= loadAndApplyTemplate "templates/news/page.html" ctxt
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
+                >>= relativizeUrls
 
--- press -----------------------------------------------------------------------------------------------
+    -- press -----------------------------------------------------------------------------------------------
     match "press/**.markdown" $ compile pandocCompiler
     create ["news/press/index.html"] $ do
         route idRoute
@@ -148,15 +153,15 @@ main = hakyll $ do
             press <- recentFirst =<< loadAll ("press/*.markdown" .&&. hasNoVersion)
 
             let ctx =
-                    listField "press_articles" defaultContext (return press) <>
-                    defaultContext
+                    listField "press_articles" defaultContext (return press)
+                        <> defaultContext
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/press/list.html"    ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"   sponsors
+                >>= loadAndApplyTemplate "templates/press/list.html" ctx
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- faq ------------------------------------------------------------------------------------------------
+    -- faq ------------------------------------------------------------------------------------------------
     match "faq/*.markdown" $ compile pandocCompiler
     create ["faq/index.html"] $ do
         route idRoute
@@ -165,11 +170,11 @@ main = hakyll $ do
             ctx <- faqCtx <$> loadAll ("faq/*.markdown" .&&. hasNoVersion)
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/faq/list.html"      ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"   sponsors
+                >>= loadAndApplyTemplate "templates/faq/list.html" ctx
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- who we are ------------------------------------------------------------------------------------------
+    -- who we are ------------------------------------------------------------------------------------------
     match "who-we-are/people/*.markdown" $ compile pandocCompiler
     create ["who-we-are/index.html"] $ do
         route idRoute
@@ -179,7 +184,7 @@ main = hakyll $ do
 
             makeItem ""
                 >>= loadAndApplyTemplate "templates/who-we-are/exec-and-board.html" ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"               sponsors
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
     create ["who-we-are/past-boards/index.html"] $ do
@@ -190,10 +195,10 @@ main = hakyll $ do
 
             makeItem ""
                 >>= loadAndApplyTemplate "templates/who-we-are/past-board.html" ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"           sponsors
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- podcast ---------------------------------------------------------------------------------------------
+    -- podcast ---------------------------------------------------------------------------------------------
     create ["podcast/index.html"] $ do
         route idRoute
         compile $ do
@@ -201,8 +206,8 @@ main = hakyll $ do
             ctx <- podcastListCtx . sortOn podcastOrd <$> loadAll ("podcast/*/index.markdown" .&&. hasVersion "raw")
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/podcast/list.html"  ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"   sponsors
+                >>= loadAndApplyTemplate "templates/podcast/list.html" ctx
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
     match "podcast/*/index.markdown" $ do
@@ -212,25 +217,26 @@ main = hakyll $ do
             -- extract the captures path fragment. really no easier way?
             episode <- head . fromJust . capture "podcast/*/index.markdown" <$> getUnderlying
 
-            let ctxt = mconcat
-                  [ field "transcript" $ \_ -> do
-                       loadBody (fromCaptures "podcast/*/transcript.markdown" [episode])
-                  , field "links" $ \_ -> do
-                       loadBody (fromCaptures "podcast/*/links.markdown" [episode])
-                  , defaultContext
-                  ]
+            let ctxt =
+                    mconcat
+                        [ field "transcript" $ \_ -> do
+                            loadBody (fromCaptures "podcast/*/transcript.markdown" [episode])
+                        , field "links" $ \_ -> do
+                            loadBody (fromCaptures "podcast/*/links.markdown" [episode])
+                        , defaultContext
+                        ]
 
             pandocCompiler
                 >>= applyAsTemplate sponsors
                 >>= loadAndApplyTemplate "templates/podcast/episode.html" ctxt
-                >>= loadAndApplyTemplate "templates/boilerplate.html"     sponsors
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
     match "podcast/*/index.markdown" $ version "raw" $ compile pandocCompiler
     match "podcast/*/transcript.markdown" $ compile pandocCompiler
     match "podcast/*/links.markdown" $ compile pandocCompiler
 
--- Events
+    -- Events
 
     create ["events/index.html"] $ do
         route idRoute
@@ -244,18 +250,19 @@ main = hakyll $ do
                 >>= relativizeUrls
 
     match "events/*.markdown" $ do
-      route $ setExtension "html"
-      let ctxt = mconcat
-            [ defaultContext ]
-      compile $ do
-        sponsors <- buildBoilerplateCtx Nothing
-        pandocCompiler
-          >>= applyAsTemplate sponsors
-          >>= loadAndApplyTemplate "templates/events/page.html" ctxt
-          >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
-          >>= relativizeUrls
+        route $ setExtension "html"
+        let ctxt =
+                mconcat
+                    [defaultContext]
+        compile $ do
+            sponsors <- buildBoilerplateCtx Nothing
+            pandocCompiler
+                >>= applyAsTemplate sponsors
+                >>= loadAndApplyTemplate "templates/events/page.html" ctxt
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
+                >>= relativizeUrls
 
--- Partnerships
+    -- Partnerships
 
     create ["partnerships/index.html"] $ do
         route idRoute
@@ -269,18 +276,19 @@ main = hakyll $ do
                 >>= relativizeUrls
 
     match "partnerships/*.markdown" $ do
-      route $ setExtension "html"
-      let ctxt = mconcat
-            [ defaultContext ]
-      compile $ do
-        sponsors <- buildBoilerplateCtx Nothing
-        pandocCompiler
-          >>= applyAsTemplate sponsors
-          >>= loadAndApplyTemplate "templates/partnerships/page.html" ctxt
-          >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
-          >>= relativizeUrls
+        route $ setExtension "html"
+        let ctxt =
+                mconcat
+                    [defaultContext]
+        compile $ do
+            sponsors <- buildBoilerplateCtx Nothing
+            pandocCompiler
+                >>= applyAsTemplate sponsors
+                >>= loadAndApplyTemplate "templates/partnerships/page.html" ctxt
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
+                >>= relativizeUrls
 
--- Reports
+    -- Reports
     create ["reports/index.html"] $ do
         route idRoute
         compile $ do
@@ -293,42 +301,44 @@ main = hakyll $ do
                 >>= relativizeUrls
 
     match "reports/*.markdown" $ do
-      route . customRoute $ \ ident ->
-        let (ctx, nameMd) = splitFileName $ toFilePath ident
-        in ctx </> dropExtension nameMd </> "index.html"
-      let ctxt = mconcat
-            [ defaultContext, reportCtx ]
-      compile $ do
-        sponsors <- buildBoilerplateCtx Nothing
-        let readerOpts = defaultHakyllReaderOptions {
-              readerExtensions =
-                disableExtension Ext_tex_math_dollars $
-                  readerExtensions defaultHakyllReaderOptions
-              }
-        pandocCompilerWith readerOpts defaultHakyllWriterOptions
-          >>= applyAsTemplate sponsors
-          >>= loadAndApplyTemplate "templates/reports/page.html" ctxt
-          >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
-          >>= relativizeUrls
+        route . customRoute $ \ident ->
+            let (ctx, nameMd) = splitFileName $ toFilePath ident
+             in ctx </> dropExtension nameMd </> "index.html"
+        let ctxt =
+                mconcat
+                    [defaultContext, reportCtx]
+        compile $ do
+            sponsors <- buildBoilerplateCtx Nothing
+            let readerOpts =
+                    defaultHakyllReaderOptions
+                        { readerExtensions =
+                            disableExtension Ext_tex_math_dollars $
+                                readerExtensions defaultHakyllReaderOptions
+                        }
+            pandocCompilerWith readerOpts defaultHakyllWriterOptions
+                >>= applyAsTemplate sponsors
+                >>= loadAndApplyTemplate "templates/reports/page.html" ctxt
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
+                >>= relativizeUrls
 
     match "reports/*/*.png" $ do
-      route idRoute
-      compile copyFileCompiler
+        route idRoute
+        compile copyFileCompiler
 
--- Description compiler --------------------------------------------------------------------------------
---
--- This identifier compiles the body the file to plain text, to be used in the OpenGraph description field
+    -- Description compiler --------------------------------------------------------------------------------
+    --
+    -- This identifier compiles the body the file to plain text, to be used in the OpenGraph description field
 
     match "**/*.markdown" $ version "description" $ compile pandocPlainCompiler
 
--- home page -------------------------------------------------------------------------------------------
+    -- home page -------------------------------------------------------------------------------------------
     create ["index.html"] $ do
         route idRoute
         compile $ do
             sponsors <- buildBoilerplateCtx (Just "Haskell Foundation")
             podcastsCtx <- podcastListCtx . take 1 . reverse . sortOn podcastOrd <$> loadAll ("podcast/*/index.markdown" .&&. hasVersion "raw")
             careersCtx <- careersCtx . reverse <$> loadAll ("careers/*.markdown" .&&. hasNoVersion)
-            announces  <- take 1 <$> (recentFirst =<< loadAll @String ("news/*/**.markdown" .&&. hasNoVersion))
+            announces <- take 1 <$> (recentFirst =<< loadAll @String ("news/*/**.markdown" .&&. hasNoVersion))
             let announceCtx = announcementsCtx announces
             eventsCtx <- activeEventsCtx <$> (recentFirst =<< loadAll ("events/*.markdown" .&&. hasNoVersion))
 
@@ -337,7 +347,7 @@ main = hakyll $ do
                 >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- general 'static' pages ------------------------------------------------------------------------------
+    -- general 'static' pages ------------------------------------------------------------------------------
     match "**/index.html" $ do
         route idRoute
         compile $ do
@@ -347,7 +357,7 @@ main = hakyll $ do
                 >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- resources -------------------------------------------------------------------------------------------
+    -- resources -------------------------------------------------------------------------------------------
     match "resources/*.markdown" $ compile pandocCompiler
     create ["resources/index.html"] $ do
         route idRoute
@@ -356,15 +366,15 @@ main = hakyll $ do
             resources <- loadAll ("resources/*.markdown" .&&. hasNoVersion)
 
             let ctx =
-                    listField "resources" defaultContext (return resources) <>
-                    defaultContext
+                    listField "resources" defaultContext (return resources)
+                        <> defaultContext
 
             makeItem ""
-                >>= loadAndApplyTemplate "templates/resources/list.html"    ctx
-                >>= loadAndApplyTemplate "templates/boilerplate.html"       sponsors
+                >>= loadAndApplyTemplate "templates/resources/list.html" ctx
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- 404 -------------------------------------------------------------------------------------------------
+    -- 404 -------------------------------------------------------------------------------------------------
     match "404.html" $ do
         route idRoute
         compile $ do
@@ -373,7 +383,7 @@ main = hakyll $ do
                 >>= applyAsTemplate sponsors
                 >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
 
--- careers ---------------------------------------------------------------------------------------------
+    -- careers ---------------------------------------------------------------------------------------------
     create ["careers/index.html"] $ do
         route idRoute
         compile $ do
@@ -392,11 +402,11 @@ main = hakyll $ do
             sponsors <- buildBoilerplateCtx Nothing
             pandocCompiler
                 >>= applyAsTemplate sponsors
-                >>= loadAndApplyTemplate "templates/careers/page.html"    defaultContext
-                >>= loadAndApplyTemplate "templates/boilerplate.html"     sponsors
+                >>= loadAndApplyTemplate "templates/careers/page.html" defaultContext
+                >>= loadAndApplyTemplate "templates/boilerplate.html" sponsors
                 >>= relativizeUrls
 
--- templates -------------------------------------------------------------------------------------------
+    -- templates -------------------------------------------------------------------------------------------
     match "templates/*" $ compile templateBodyCompiler
     match "templates/**" $ compile templateBodyCompiler
 
@@ -410,109 +420,117 @@ buildBoilerplateCtx :: Maybe String -> Compiler (Context String)
 buildBoilerplateCtx mtitle =
     boilerPlateCtx mtitle . sortOn itemIdentifier <$> loadAll ("donations/sponsors/*.markdown" .&&. hasNoVersion)
 
--- | Partition sponsors into by level: monad, applicative, and functor
--- Sponsors are listed in the footer template, which means we need this
--- context for most pages.
---
--- We set the 'title' based on the title metadata for the item, if present,
--- or use the passed in Maybe title, if it is a Just, or "No title" if not.
+{- | Partition sponsors into by level: Gold, silver, and bronze
+Sponsors are listed in the footer template, which means we need this
+context for most pages.
+
+We set the 'title' based on the title metadata for the item, if present,
+or use the passed in Maybe title, if it is a Just, or "No title" if not.
+-}
 boilerPlateCtx :: Maybe String -> [Item String] -> Context String
-boilerPlateCtx mtitle sponsors = mconcat
-    [ listField "monads" defaultContext (ofMetadataField "level" "Monad" sponsors)
-    , listField "applicatives" defaultContext (ofMetadataField "level" "Applicative" sponsors)
-    , listField "functors" defaultContext (ofMetadataField "level" "Functor" sponsors)
-    , field "title" $ \item -> do
-        metadata <- getMetadata (itemIdentifier item)
-        return $ fromMaybe (fromMaybe "No title" mtitle) $ lookupString "title" metadata
-    , field "description" $ \item -> do
-        desc <- loadBody (setVersion (Just "description") (itemIdentifier item))
-        if null desc then noResult "Description empty" else pure (escapeHtml desc)
-    , defaultContext
-    ]
+boilerPlateCtx mtitle sponsors =
+    mconcat
+        [ listField "golds" defaultContext (ofMetadataField "level" "Gold" sponsors)
+        , listField "silvers" defaultContext (ofMetadataField "level" "Silver" sponsors)
+        , listField "bronzes" defaultContext (ofMetadataField "level" "Bronze" sponsors)
+        , field "title" $ \item -> do
+            metadata <- getMetadata (itemIdentifier item)
+            return $ fromMaybe (fromMaybe "No title" mtitle) $ lookupString "title" metadata
+        , field "description" $ \item -> do
+            desc <- loadBody (setVersion (Just "description") (itemIdentifier item))
+            if null desc then noResult "Description empty" else pure (escapeHtml desc)
+        , defaultContext
+        ]
 
 -- affiliates ------------------------------------------------------------------------------------------
+
 -- | Partition affiliates into affiliates and pending
 affiliatesCtx :: [Item String] -> Context String
 affiliatesCtx affiliates =
-    listField "affiliated" defaultContext (ofMetadataField "status" "affiliated" affiliates)  <>
-    listField "pending" defaultContext (ofMetadataField "status" "pending" affiliates)        <>
-    defaultContext
+    listField "affiliated" defaultContext (ofMetadataField "status" "affiliated" affiliates)
+        <> listField "pending" defaultContext (ofMetadataField "status" "pending" affiliates)
+        <> defaultContext
 
 -- projects --------------------------------------------------------------------------------------------
+
 -- | Partition projects into : Ideation | Proposed | In Progress | Completed
 projectsCtx :: [Item String] -> Context String
 projectsCtx projects =
-    listField "ideas" projectContext (ofMetadataField "status" "ideation" projects)        <>
-    listField "proposals" projectContext (ofMetadataField "status" "proposed" projects)    <>
-    listField "inprogress" projectContext (ofMetadataField "status" "inprogress" projects) <>
-    listField "completed" projectContext (ofMetadataField "status" "completed" projects)   <>
-    defaultContext
-  where projectContext =
-          slugField "id" <>
-          defaultContext
+    listField "ideas" projectContext (ofMetadataField "status" "ideation" projects)
+        <> listField "proposals" projectContext (ofMetadataField "status" "proposed" projects)
+        <> listField "inprogress" projectContext (ofMetadataField "status" "inprogress" projects)
+        <> listField "completed" projectContext (ofMetadataField "status" "completed" projects)
+        <> defaultContext
+  where
+    projectContext =
+        slugField "id"
+            <> defaultContext
 
 slugField :: String -> Context a
 slugField name =
-  field name $ pure . takeBaseName . toFilePath . itemIdentifier
+    field name $ pure . takeBaseName . toFilePath . itemIdentifier
 
 -- news ------------------------------------------------------------------------------------------------
+
 -- | build group of news inside date of publishing (category)
 newsWithCategoriesCtx :: Tags -> Context String
 newsWithCategoriesCtx categories =
-    listField "categories" categoryCtx getAllCategories <>
-    defaultContext
-        where
-            getAllCategories :: Compiler [Item (String, [Identifier])]
-            getAllCategories = pure . map buildItemFromTag $ tagsMap categories
-                where
-                    buildItemFromTag :: (String, [Identifier]) -> Item (String, [Identifier])
-                    buildItemFromTag c@(name, _) = Item (tagsMakeId categories name) c
-            categoryCtx :: Context (String, [Identifier])
-            categoryCtx =
-                listFieldWith "news" newsCtx getNews        <>
-                metadataField                               <>
-                urlField "url"                              <>
-                pathField "path"                            <>
-                titleField "title"                          <>
-                missingField
-                    where
-                        getNews:: Item (String, [Identifier]) -> Compiler [Item String]
-                        getNews (itemBody -> (_, ids)) = mapM load ids
-                        newsCtx :: Context String
-                        newsCtx = newsWithCategoriesCtx categories
+    listField "categories" categoryCtx getAllCategories
+        <> defaultContext
+  where
+    getAllCategories :: Compiler [Item (String, [Identifier])]
+    getAllCategories = pure . map buildItemFromTag $ tagsMap categories
+      where
+        buildItemFromTag :: (String, [Identifier]) -> Item (String, [Identifier])
+        buildItemFromTag c@(name, _) = Item (tagsMakeId categories name) c
+    categoryCtx :: Context (String, [Identifier])
+    categoryCtx =
+        listFieldWith "news" newsCtx getNews
+            <> metadataField
+            <> urlField "url"
+            <> pathField "path"
+            <> titleField "title"
+            <> missingField
+      where
+        getNews :: Item (String, [Identifier]) -> Compiler [Item String]
+        getNews (itemBody -> (_, ids)) = mapM load ids
+        newsCtx :: Context String
+        newsCtx = newsWithCategoriesCtx categories
 
 -- faq -------------------------------------------------------------------------------------------------
 faqCtx :: [Item String] -> Context String
 faqCtx entries =
-    listField "faq_entries" defaultContext (sortFromMetadataField "order" entries) <>
-    defaultContext
+    listField "faq_entries" defaultContext (sortFromMetadataField "order" entries)
+        <> defaultContext
 
 -- who we are ------------------------------------------------------------------------------------------
 whoWeAreCtx :: [Item String] -> Context String
 whoWeAreCtx people =
-    listField "currentexecutiveteam" defaultContext (ofMetadataFieldCurrent True "executiveTeam" "True" people) <>
-    listField "currentboard" defaultContext (ofMetadataFieldCurrent True "executiveTeam" "False" people)        <>
-    listField "pastexecutiveteam" defaultContext (ofMetadataFieldCurrent False "executiveTeam" "True" people)   <>
-    listField "pastboard" defaultContext  (ofMetadataFieldCurrent False "executiveTeam" "False" people)         <>
-    listField "interimboard" defaultContext (ofMetadataField "interimBoard" "True" people)                      <>
-    defaultContext
-    where
-        ofMetadataFieldCurrent :: Bool -> String -> String -> [Item String] -> Compiler [Item String]
-        ofMetadataFieldCurrent cur field value items = do
-            items' <- ofMetadataField field value items
-            filterM (\item -> do
+    listField "currentexecutiveteam" defaultContext (ofMetadataFieldCurrent True "executiveTeam" "True" people)
+        <> listField "currentboard" defaultContext (ofMetadataFieldCurrent True "executiveTeam" "False" people)
+        <> listField "pastexecutiveteam" defaultContext (ofMetadataFieldCurrent False "executiveTeam" "True" people)
+        <> listField "pastboard" defaultContext (ofMetadataFieldCurrent False "executiveTeam" "False" people)
+        <> listField "interimboard" defaultContext (ofMetadataField "interimBoard" "True" people)
+        <> defaultContext
+  where
+    ofMetadataFieldCurrent :: Bool -> String -> String -> [Item String] -> Compiler [Item String]
+    ofMetadataFieldCurrent cur field value items = do
+        items' <- ofMetadataField field value items
+        filterM
+            ( \item -> do
                 mbTenureStart <- getMetadataField (itemIdentifier item) "tenureStart"
                 mbTenureStop <- getMetadataField (itemIdentifier item) "tenureEnd"
                 pure $ case mbTenureStop of
                     Nothing -> cur && isJust mbTenureStart
                     Just date -> not cur
-             ) items'
+            )
+            items'
 
 -- podcast ---------------------------------------------------------------------------------------------
 podcastListCtx :: [Item String] -> Context String
 podcastListCtx episodes =
-    listField "episodes" defaultContext (return $ reverse episodes) <>
-    defaultContext
+    listField "episodes" defaultContext (return $ reverse episodes)
+        <> defaultContext
 
 podcastOrd :: Item String -> Integer
 podcastOrd = read . head . fromJust . capture "podcast/*/index.markdown" . itemIdentifier
@@ -520,44 +538,44 @@ podcastOrd = read . head . fromJust . capture "podcast/*/index.markdown" . itemI
 -- careers ---------------------------------------------------------------------------------------------
 careersCtx :: [Item String] -> Context String
 careersCtx reqs =
-    listField "openreqs" defaultContext (ofMetadataField "status" "Open" reqs) <>
-    listField "closedreqs" defaultContext (ofMetadataField "status" "Closed" reqs) <>
-    defaultContext
+    listField "openreqs" defaultContext (ofMetadataField "status" "Open" reqs)
+        <> listField "closedreqs" defaultContext (ofMetadataField "status" "Closed" reqs)
+        <> defaultContext
 
 hiringSponsorsCtx :: [Item String] -> Context String
 hiringSponsorsCtx sponsors =
-    listField "hiringsponsors" defaultContext (filterMetadataField "careersUrl" sponsors) <>
-    defaultContext
+    listField "hiringsponsors" defaultContext (filterMetadataField "careersUrl" sponsors)
+        <> defaultContext
 
 -- Anouncements
 
 announcementsCtx :: [Item String] -> Context String
 announcementsCtx ads =
-  listField "announcements" defaultContext (pure ads)
+    listField "announcements" defaultContext (pure ads)
 
 -- Events
 
 allEventsCtx :: [Item String] -> Context String
 allEventsCtx evts =
-    listField "events" defaultContext (pure evts) <>
-    defaultContext
+    listField "events" defaultContext (pure evts)
+        <> defaultContext
 
 activeEventsCtx :: [Item String] -> Context String
 activeEventsCtx evts =
-  listField "events" defaultContext (ofMetadataField "status" "active" evts) <>
-  defaultContext
+    listField "events" defaultContext (ofMetadataField "status" "active" evts)
+        <> defaultContext
 
 partnershipCtx :: [Item String] -> Context String
 partnershipCtx evts =
-    listField "partnerships" defaultContext (pure evts) <>
-    defaultContext
+    listField "partnerships" defaultContext (pure evts)
+        <> defaultContext
 
 -- Reports
 
 allReportsCtx :: [Item String] -> Context String
 allReportsCtx evts =
-    listField "reports" (defaultContext <> reportCtx) (pure evts) <>
-    defaultContext
+    listField "reports" (defaultContext <> reportCtx) (pure evts)
+        <> defaultContext
 
 reportCtx :: Context String
 reportCtx = dateField "date" "%B %d, %0Y"
@@ -569,53 +587,66 @@ reportCtx = dateField "date" "%B %d, %0Y"
 -- | filter list of item string based on whether or not the field exists
 filterMetadataField :: String -> [Item String] -> Compiler [Item String]
 filterMetadataField field =
-    filterM (\item -> do
-        mbField <- getMetadataField (itemIdentifier item) field
-        return $ isJust mbField
-    )
+    filterM
+        ( \item -> do
+            mbField <- getMetadataField (itemIdentifier item) field
+            return $ isJust mbField
+        )
 
 -- | filter list of item string based on the given value to match on the given metadata field
 ofMetadataField :: String -> String -> [Item String] -> Compiler [Item String]
 ofMetadataField field value items = do
-  matching <- filterM (\item -> do
-        mbField <- getMetadataField (itemIdentifier item) field
-        return $ Just value == mbField) items
-  guard (not (null matching))
-  pure matching
+    matching <-
+        filterM
+            ( \item -> do
+                mbField <- getMetadataField (itemIdentifier item) field
+                return $ Just value == mbField
+            )
+            items
+    guard (not (null matching))
+    pure matching
 
 -- | sort list of item based on the given metadata field
 sortFromMetadataField :: String -> [Item String] -> Compiler [Item String]
-sortFromMetadataField field = sortByM (\a b -> do
-        a' <- getMetadataField (itemIdentifier a) field
-        b' <- getMetadataField (itemIdentifier b) field
-        return $ compare a' b'
-    )
+sortFromMetadataField field =
+    sortByM
+        ( \a b -> do
+            a' <- getMetadataField (itemIdentifier a) field
+            b' <- getMetadataField (itemIdentifier b) field
+            return $ compare a' b'
+        )
 
 --------------------------------------------------------------------------------------------------------
 -- Pandoc extensions -----------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------------------------
 
--- | Read a page render using pandoc, rendering its first paragraph as a plain string
---
--- Cargo-culted from pandocCompiler
-pandocPlainCompiler :: Compiler (Item String)
-pandocPlainCompiler = cached "pandocPlainCompiler" $
-    getResourceBody >>=
-      readPandocWith defaultHakyllReaderOptions >>=
-      pure . fmap firstPara >>=
-      pure . writePandocPlainWith defaultHakyllWriterOptions
+{- | Read a page render using pandoc, rendering its first paragraph as a plain string
 
--- | Write a document's first paragraph (as plain text) using pandoc, with the supplied options
---
--- Cargo-culted from hakyll’s writePandocWith
-writePandocPlainWith :: Pandoc.WriterOptions  -- ^ Writer options for pandoc
-                -> Item Pandoc.Pandoc    -- ^ Document to write
-                -> Item String    -- ^ Resulting HTML
+Cargo-culted from pandocCompiler
+-}
+pandocPlainCompiler :: Compiler (Item String)
+pandocPlainCompiler =
+    cached "pandocPlainCompiler" $
+        getResourceBody
+            >>= readPandocWith defaultHakyllReaderOptions
+            >>= pure . fmap firstPara
+            >>= pure . writePandocPlainWith defaultHakyllWriterOptions
+
+{- | Write a document's first paragraph (as plain text) using pandoc, with the supplied options
+
+Cargo-culted from hakyll’s writePandocWith
+-}
+writePandocPlainWith ::
+    -- | Writer options for pandoc
+    Pandoc.WriterOptions ->
+    -- | Document to write
+    Item Pandoc.Pandoc ->
+    -- | Resulting HTML
+    Item String
 writePandocPlainWith wopt (Item itemi doc) =
     case runPure $ writePlain wopt doc of
-        Left err    -> error $ "Hakyll.Web.Pandoc.writePandocWith: " ++ show err
+        Left err -> error $ "Hakyll.Web.Pandoc.writePandocWith: " ++ show err
         Right item' -> Item itemi $ T.unpack item'
-
 
 -- | Finds the first regular paragraph of a Pandoc doc
 firstPara :: Pandoc.Pandoc -> Pandoc.Pandoc
@@ -624,5 +655,5 @@ firstPara (Pandoc.Pandoc meta blocks) = Pandoc.Pandoc meta (go blocks)
     go :: [Pandoc.Block] -> [Pandoc.Block]
     go [] = [] -- I tried to use noResult "firstPara: No plain text found", but it made the build fail
     go (block@(Pandoc.Plain _) : _) = [block]
-    go (block@(Pandoc.Para _)  : _) = [block]
+    go (block@(Pandoc.Para _) : _) = [block]
     go (_ : bs) = go bs

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -5,7 +5,7 @@
     <div class="font-bold">Gold</div>
   </div>
   <div class="flex flex-wrap items-center justify-center">
-    $for(monads)$
+    $for(golds)$
     <a href="$externalUrl$" target="_blank" class="block w-48 m-4"><img alt="$title$" src="$logo$" $if(srcset)$ srcset="$srcset$" $endif$></a>
     $endfor$
   </div>
@@ -14,7 +14,7 @@
     <div class="font-bold">Silver</div>
   </div>
   <div class="flex flex-wrap items-center justify-center">
-    $for(applicatives)$
+    $for(silvers)$
     <a href="$externalUrl$" target="_blank" class="block w-36 m-4"><img alt="$title$" src="$logo$" $if(srcset)$ srcset="$srcset$" $endif$></a>
     $endfor$
   </div>
@@ -23,7 +23,7 @@
     <div class="font-bold">Bronze</div>
   </div>
   <div class="flex flex-wrap items-center justify-center">
-    $for(functors)$
+    $for(bronzes)$
     <a href="$externalUrl$" target="_blank" class="block w-24 m-4"><img alt="$title$" src="$logo$" $if(srcset)$ srcset="$srcset$" $endif$></a>
     $endfor$
   </div>


### PR DESCRIPTION
This pull request updates sponsor status as of June 2026. Obsidian Systems wasn't listed, for example.

I also renamed the internal levels (functor, applicative, monad) to match the external levels (bronze, silver, and gold) 