### PR TITLE
Remove Jose from active exec team and assorted tweaks

### DIFF
--- a/site.hs
+++ b/site.hs
@@ -535,7 +535,7 @@ faqCtx entries =
 whoWeAreCtx :: [Item String] -> Context String
 whoWeAreCtx people =
     listField "currentexecutiveteam" defaultContext (ofMetadataFieldCurrent True "executiveTeam" "True" people)
-        <> listField "currentboard" defaultContext (ofMetadataFieldCurrent True "executiveTeam" "False" people)
+        <> listField "currentboard" defaultContext (ofMetadataFieldCurrent True "executiveTeam" "False" people >>= sortBoardByRole)
         <> listField "pastexecutiveteam" defaultContext (ofMetadataFieldCurrent False "executiveTeam" "True" people)
         <> listField "pastboard" defaultContext (ofMetadataFieldCurrent False "executiveTeam" "False" people)
         <> listField "interimboard" defaultContext (ofMetadataField "interimBoard" "True" people)
@@ -544,15 +544,21 @@ whoWeAreCtx people =
     ofMetadataFieldCurrent :: Bool -> String -> String -> [Item String] -> Compiler [Item String]
     ofMetadataFieldCurrent cur field value items = do
         items' <- ofMetadataField field value items
-        filterM
-            ( \item -> do
-                mbTenureStart <- getMetadataField (itemIdentifier item) "tenureStart"
-                mbTenureStop <- getMetadataField (itemIdentifier item) "tenureEnd"
-                pure $ case mbTenureStop of
-                    Nothing -> cur && isJust mbTenureStart
-                    Just date -> not cur
-            )
-            items'
+        current <-
+            filterM
+                ( \item -> do
+                    mbTenureStart <- getMetadataField (itemIdentifier item) "tenureStart"
+                    mbTenureStop <- getMetadataField (itemIdentifier item) "tenureEnd"
+                    pure $ case mbTenureStop of
+                        Nothing -> cur && isJust mbTenureStart
+                        Just date -> not cur
+                )
+                items'
+        -- Fail (rather than return an empty list) when nobody matches, so the
+        -- corresponding listField is *absent* and `$if(...)$` in templates is
+        -- False. Otherwise an empty list still counts as "present".
+        guard (not (null current))
+        pure current
 
 -- podcast ---------------------------------------------------------------------------------------------
 podcastListCtx :: [Item String] -> Context String
@@ -643,6 +649,53 @@ sortFromMetadataField field =
             b' <- getMetadataField (itemIdentifier b) field
             return $ compare a' b'
         )
+
+{- | A board member's role. The ordering of the constructors is significant: the
+derived 'Ord' instance ranks roles in the order they should appear on the
+"Who We Are" page (Chair first, officers next, plain members, then observers).
+Reorder the constructors to change the display order.
+-}
+data Role
+    = Chair
+    | ViceChair
+    | Treasurer
+    | ViceTreasurer
+    | Secretary
+    | ViceSecretary
+    | BoardMember
+    | Observer
+    deriving (Eq, Ord, Show)
+
+{- | Parse a board member's @title@ metadata into a 'Role'. Unknown titles are a
+build error, so any new role must be handled explicitly here.
+-}
+parseRole :: String -> Either String Role
+parseRole title = case title of
+    "Chair" -> Right Chair
+    "Vice Chair" -> Right ViceChair
+    "Treasurer" -> Right Treasurer
+    "Vice Treasurer" -> Right ViceTreasurer
+    "Secretary" -> Right Secretary
+    "Vice Secretary" -> Right ViceSecretary
+    "Vice-Secretary" -> Right ViceSecretary
+    "Board Member" -> Right BoardMember
+    "Observer" -> Right Observer
+    _ -> Left ("parseRole: unexpected board role " ++ show title)
+
+{- | Sort board members by their 'Role', so that officers appear first (Chair,
+then Vice Chair, Treasurer, and so on) and regular board members follow. A
+member with no @title@ is treated as a plain 'BoardMember'; members sharing a
+role keep their relative order thanks to the stable sort.
+-}
+sortBoardByRole :: [Item String] -> Compiler [Item String]
+sortBoardByRole items = do
+    ranked <- mapM tagWithRole items
+    pure $ map snd $ sortOn fst ranked
+  where
+    tagWithRole item = do
+        title <- fromMaybe "Board Member" <$> getMetadataField (itemIdentifier item) "title"
+        role <- either fail pure (parseRole title)
+        pure (role, item)
 
 --------------------------------------------------------------------------------------------------------
 -- Pandoc extensions -----------------------------------------------------------------------------------

--- a/templates/who-we-are/exec-and-board.html
+++ b/templates/who-we-are/exec-and-board.html
@@ -5,6 +5,8 @@
   </div>
 </div>
 
+<!-- The Haskell Foundation has had no active executive team members at times, hence the if/endif block -->
+$if(currentexecutiveteam)$
 <div class="xl:max-w-screen-xl mx-auto md:px-12 lg:px-16">
   <div class="bg-gray-800 shadow-lg shadow-xl shadow-md shadow-sm px-6 sm:px-12 md:px-12 lg:px-16 py-16 md:py-20">
     <h2 class="text-gray-50 font-normal text-3xl-4xl text-center">Executive Team</h2>
@@ -41,13 +43,14 @@
     $endfor$
   </div>
 </div>
+$endif$
 
 <div class="xl:max-w-screen-xl mx-auto md:px-12 lg:px-16">
   <div class="bg-gray-800 shadow-lg shadow-xl shadow-md shadow-sm px-6 sm:px-12 md:px-12 lg:px-16 py-16 md:py-20">
-    <h2 class="text-gray-50 font-normal text-3xl-4xl text-center">The HF Board Of Directors</h2>
+    <h2 class="text-gray-50 font-normal text-3xl-4xl text-center">The Board of Directors</h2>
     <p class="mt-10 lg:text-xl text-gray-300 leading-relaxed text-center">
 
-      The Haskell Foundation board of directors are responsible for managing and setting the direction of the Haskell Foundation.
+      The Haskell Foundation Board of directors are responsible for managing and setting the direction of the Haskell Foundation.
 
     </p>
   </div>

--- a/who-we-are/people/josecalderon.markdown
+++ b/who-we-are/people/josecalderon.markdown
@@ -4,6 +4,7 @@ email: jmct@haskell.foundation
 title: Executive Director
 executiveTeam: "True"
 tenureStart: 2023-11-09
+tenureEnd: 2026-06-30
 image: /assets/images/exec-team/jmct.png
 website: http://jmct.cc
 ---

--- a/who-we-are/people/laurentprenedecotret.markdown
+++ b/who-we-are/people/laurentprenedecotret.markdown
@@ -11,6 +11,6 @@ website: https://laurentrdc.xyz
 
 Laurent joined the Haskell community in 2017. He participates a lot in open-source software developement, and maintains several projects such as Cloud Haskell, Beam, and Hakyll. One of his goals for the Haskell Foundation is to expand the reach of Haskell in industry, by facilitating the learning experience for people curious about Haskell.
 
-Laurent has a PhD in Physics, with a focus on quantum condensed matter. His personal interests include the application of Haskell for high-performance scientific computing, distributed systems, and data science. Today, Laurent works at Bitnomial, a fintech startup running a commodity derivatives exchange and clearinghouse, and whose entire backend is built in Haskell.
+Laurent has a PhD in Physics, with a focus on quantum condensed matter. His interests include the application of Haskell for high-performance scientific computing, distributed systems, and data science. Today, Laurent works at Bitnomial, a fintech company running a commodity derivatives exchange and clearinghouse, and whose entire backend is built in Haskell.
 
 Do not hesitate to reach out!


### PR DESCRIPTION
This PR adds a `tenureEnd` to Jose's profile, and makes the "executive team" section optional on the "Who we are" page.

The ordering of board members has also been updated, such that board officers are listed first.