### PR TITLE
Build the Nix dev shell from the Cabal file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,5 @@
-## Description
+---
 
-<!-- What does this PR do, and why? -->
-
-## Checklist
+### Checklist
 
 - [ ] Titles and headings use [AP Title Case](https://titlecaseconverter.com/) (see [Style Guide](../CONTRIBUTING.md#style-guide))

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ node_modules/
 
 ### General ###
 *~
+
+# macOS
 .DS_Store
 
+# Nix
 /.direnv/
+/result
+/result-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ npm run build     # compile -> assets/css/tailwind.built.css
 npm run watch     # same, then recompile on source/content changes
 ```
 
-If you do not want to install `npm` globally and have `nix` available, drop into the Nix development shell which provides `npm` and a basic Haskell toolchain.
+If you do not want to install `npm` globally and have `nix` available, `nix develop` drops you into a shell with `npm` and the Haskell toolchain, including every dependency of the site generator prebuilt — so `cabal build` compiles only `site.hs` instead of spending half an hour on Pandoc. `nix build` alone gives you the `site` executable without a shell.
 
 **Commit the regenerated `assets/css/tailwind.built.css` with your change.** CI reruns `npm run build` on every push and PR and fails if the committed copy has drifted, so a stale stylesheet cannot reach the live site.
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,25 +18,41 @@
       ];
       perSystem =
         {
+          lib,
           pkgs,
           ...
         }:
+        let
+          haskellPkgs = pkgs.haskellPackages;
+
+          # Only the Haskell sources; the site content is read at run time.
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./haskell-foundation.cabal
+              ./site.hs
+              ./tools/social-crossposting
+            ];
+          };
+
+          haskell-foundation = haskellPkgs.callCabal2nix "haskell-foundation" src { };
+        in
         {
-          devShells.default = pkgs.mkShell {
+          packages.default = haskell-foundation;
+
+          devShells.default = haskellPkgs.shellFor {
+            packages = _: [ haskell-foundation ];
+
             nativeBuildInputs = [
               # Node; pinned to same version as CI.
               pkgs.nodejs_24
 
               # Haskell.
               pkgs.cabal-install
-              pkgs.ghc
               pkgs.haskell-language-server
 
               # Screenshotting pages during design work.
               (pkgs.python3.withPackages (ps: [ ps.playwright ]))
-
-              # System.
-              pkgs.zlib
             ];
 
             env = {


### PR DESCRIPTION
`callCabal2nix` derives the package from `haskell-foundation.cabal`. `cabal build` then only compiles `site.hs`, instead of spending half an hour on Pandoc.

## Checklist

- [x] Titles and headings use [AP Title Case](https://titlecaseconverter.com/) (see [Style Guide](../CONTRIBUTING.md#style-guide))
